### PR TITLE
/deploy: immediately queue check-run

### DIFF
--- a/GitForWindowsHelper/check-runs.js
+++ b/GitForWindowsHelper/check-runs.js
@@ -1,0 +1,52 @@
+const queueCheckRun = async (context, token, owner, repo, ref, checkRunName, title, summary) => {
+    const githubApiRequest = require('./github-api-request')
+    // is there an existing check-run we can re-use?
+    const { check_runs } = await githubApiRequest(
+      context,
+      token,
+      'GET',
+      `/repos/${owner}/${repo}/commits/${ref}/check-runs`
+    )
+    const filtered = check_runs
+      .filter(e => e.name === checkRunName && e.conclusion === null).map(e => {
+        return {
+          id: e.id,
+          status: e.status
+        }
+      })
+    if (filtered.length > 0) {
+      // ensure that the check_run is set to status "in progress"
+      if (filtered[0].status !== 'queued') {
+        console.log(await githubApiRequest(
+          context,
+          token,
+          'PATCH',
+          `/repos/${owner}/${repo}/check-runs/${filtered[0].id}`, {
+            status: 'queued'
+          }
+        ))
+      }
+      process.stderr.write(`Returning existing ${filtered[0].id}`)
+      return filtered[0].id
+    }
+
+    const { id } = await githubApiRequest(
+      context,
+      token,
+      'POST',
+      `/repos/${owner}/${repo}/check-runs`, {
+        name: checkRunName,
+        head_sha: ref,
+        status: 'queued',
+        output: {
+          title,
+          summary
+        }
+      }
+    )
+    return id
+  }
+
+  module.exports = {
+    queueCheckRun
+  }

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -110,6 +110,18 @@ module.exports = async (context, req) => {
 
             await thumbsUp()
 
+            const { queueCheckRun } = require('./check-runs')
+            await queueCheckRun(
+                context,
+                await getToken(),
+                'git-for-windows',
+                repo,
+                ref,
+                'build-and-deploy.yml',
+                `Build and deploy ${package_name}`,
+                `Deploying ${package_name}`
+            )
+
             const triggerWorkflowDispatch = require('./trigger-workflow-dispatch')
             const answer = await triggerWorkflowDispatch(
                 context,


### PR DESCRIPTION
The neat trick of the `build-and-deploy` workflow is that it "mirrors" a check-run into the target repository.

But that check-run is currently only mirrored once the workflow runs and executes the respective step, which necessarily takes a few seconds because the workflow first has to check out the code to run the deployment.

Let's let the GitHub App already add the check-run, in `queued` state, to provide a more immediate visual feedback to the `/deploy` command.