### PR TITLE
 /open pr: PCRE2 needs both MINGW/MSYS2 variants

### DIFF
--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -74,7 +74,7 @@ module.exports = async (context, req) => {
                 const { appendToIssueComment } = require('./issues');
                 ({ html_url: commentURL, id: commentId } = await appendToIssueComment(context, await getToken(), owner, repo, commentId, `The${packageType ? ` ${packageType}` : ''} workflow run [was started](${answer.html_url})`))
             }
-            if (!['openssl', 'curl', 'gnutls'].includes(package_name)) {
+            if (!['openssl', 'curl', 'gnutls', 'pcre2'].includes(package_name)) {
                 await openPR(package_name)
             } else {
                 await openPR(package_name, 'MSYS')


### PR DESCRIPTION
The PCRE2 package is shipped both in the MINGW and the MSYS flavor by Git for Windows. Therefore we want `/open pr` to trigger both.

While PCRE1 is also included in both flavors, it is very unlikely to recieve further updates.