### PR TITLE
update settings URL

### DIFF
--- a/test-pr-comment-delivery.js
+++ b/test-pr-comment-delivery.js
@@ -3,7 +3,8 @@
 
     // Expect a path as command-line parameter that points to a file containing
     // an event copy/pasted from
-    // https://github.com/settings/apps/gitforwindowshelper/advanced in the form:
+    // https://github.com/organizations/git-for-windows/settings/apps/gitforwindowshelper/advanced
+    // in the form:
     //
     // Headers
     //
@@ -36,8 +37,8 @@
         else req.headers[key] = value
     })
     req.rawBody = contents.substring(payloadOffset + 1)
-        // In https://github.com/settings/apps/gitforwindowshelper/advanced, the
-        // JSON is pretty-printed, but the actual webhook event avoids any
+        // In https://github.com/organizations/git-for-windows/settings/apps/gitforwindowshelper/advanced,
+        // the JSON is pretty-printed, but the actual webhook event avoids any
         // unnecessary white-space in the body
         .replace(/\r?\n\s*("[^"]*":)\s*/g, '$1')
         .replace(/\r?\n\s*/g, '')


### PR DESCRIPTION
The GitHub app has been [transferred to the git-for-windows organization]( https://github.com/git-for-windows/gfw-helper-github-app/issues/11#issuecomment-1351362989), which changed the URL for the settings. Change the comments mentioning the old URL to the new URL.

There is one remaining mention of the old URL in README.md, but that mention is in the historical context of how the app was created, so keeping the old URL is appropriate