### PR TITLE
Support aggregated issues

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -1,4 +1,4 @@
-const guessComponentUpdateDetails = (title) => {
+const guessComponentUpdateDetails = (title, body) => {
     let [ , package_name, version ] =
         title.match(/^\[New (\S+) version\] (?:[^0-9]+\s+)?(\S+)/) ||
         title.match(/^(\S+): update to v?(\d[0-9.]\S*)/) ||

--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -1,7 +1,8 @@
 const guessComponentUpdateDetails = (title, body) => {
     let [ , package_name, version ] =
-        title.match(/^\[New (\S+) version\] (?:[^0-9]+\s+)?(\S+)/) ||
+        title.match(/^\[New (\S+) version\] (?:[^0-9]+\s+)?(\S+)(?! new items)/) ||
         title.match(/^(\S+): update to v?(\d[0-9.]\S*)/) ||
+        body.match(/^# \[New (\S+) version\] (?:[^0-9]+\s+)?(\S+)/) ||
         []
     if (!package_name || !version) throw new Error(`Could not guess component-update details from title '${title}'`)
 

--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -1,8 +1,8 @@
 const guessComponentUpdateDetails = (title, body) => {
     let [ , package_name, version ] =
-        title.match(/^\[New (\S+) version\] (?:[^0-9]+\s+)?(\S+)(?! new items)/) ||
+        title.match(/^\[New (\S+) version\] (?:[^0-9]+\s+)?(\S+(?:\s+patch\s+\d+)?)(?! new items)/) ||
         title.match(/^(\S+): update to v?(\d[0-9.]\S*)/) ||
-        body.match(/^# \[New (\S+) version\] (?:[^0-9]+\s+)?(\S+)/) ||
+        body.match(/^# \[New (\S+) version\] (?:[^0-9]+\s+)?(\S+(?:\s+patch\s+\d+)?)/) ||
         []
     if (!package_name || !version) throw new Error(`Could not guess component-update details from title '${title}'`)
 
@@ -11,8 +11,8 @@ const guessComponentUpdateDetails = (title, body) => {
     else if (package_name === 'cygwin') package_name = 'msys2-runtime'
 
     version = version
-        .replace(/^(GCM |openssl-|OpenSSL_|v|V_|GnuTLS |tig-|Heimdal |cygwin-|PCRE2-)/, '')
-        .replace('_', '.')
+        .replace(/^(GCM |openssl-|OpenSSL_|v|V_|GnuTLS |tig-|Heimdal |cygwin-|PCRE2-|Bash-)/, '')
+        .replace(/_|\s+patch\s+/, '.')
         .replace(/-release$/, '')
 
     return { package_name, version }

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -53,7 +53,7 @@ module.exports = async (context, req) => {
             await checkPermissions()
 
             const { guessComponentUpdateDetails } = require('./component-updates')
-            const { package_name, version } = guessComponentUpdateDetails(req.body.issue.title)
+            const { package_name, version } = guessComponentUpdateDetails(req.body.issue.title, req.body.issue.body)
 
             await thumbsUp()
 


### PR DESCRIPTION
Our component monitoring can aggregate multiple issues into one if it would open multiple issues for the same component at the same time.  We need to treat these issues different from other issues, because their title doesn't contain version information.

This fixes #11 