### PR TITLE
Deploy i686 MSYS packages too, not only x86_64 ones

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -35,6 +35,12 @@ const prettyPackageName = (name) => {
         tig: 'Tig',
     }[name] || name
 }
+
+const isMSYSPackage = package_name => {
+    return package_name !== 'git-extra'
+        && !package_name.startsWith('mingw-w64-')
+}
+
 const guessReleaseNotes = (issue) => {
     if (!issue.pull_request
         &&issue.labels.filter(label => label.name === 'component-update').length !== 1) throw new Error(`Cannot determine release note from issue ${issue.number}`)
@@ -55,5 +61,6 @@ const guessReleaseNotes = (issue) => {
 module.exports = {
     guessComponentUpdateDetails,
     guessReleaseNotes,
-    prettyPackageName
+    prettyPackageName,
+    isMSYSPackage
 }

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -141,21 +141,33 @@ module.exports = async (context, req) => {
             )
 
             const triggerWorkflowDispatch = require('./trigger-workflow-dispatch')
-            const answer = await triggerWorkflowDispatch(
-                context,
-                await getToken(),
-                'git-for-windows',
-                'git-for-windows-automation',
-                'build-and-deploy.yml',
-                'main', {
-                    package: package_name,
-                    repo,
-                    ref,
-                    actor: commenter
-                }
-            )
+            const triggerBuild = async () =>
+                await triggerWorkflowDispatch(
+                    context,
+                    await getToken(),
+                    'git-for-windows',
+                    'git-for-windows-automation',
+                    'build-and-deploy.yml',
+                    'main', {
+                        package: package_name,
+                        repo,
+                        ref,
+                        actor: commenter
+                    }
+                )
+
             const { appendToIssueComment } = require('./issues')
-            const answer2 = await appendToIssueComment(context, await getToken(), owner, repo, commentId, `The workflow run [was started](${answer.html_url})`)
+            const appendToComment = async (text) =>
+                await appendToIssueComment(
+                    context,
+                    await getToken(),
+                    owner,
+                    repo,
+                    commentId,
+                    text
+                )
+            const answer = await triggerBuild()
+            const answer2 = await appendToComment(`The workflow run [was started](${answer.html_url})`)
             return `I edited the comment: ${answer2.html_url}`
         }
 

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -112,10 +112,8 @@ module.exports = async (context, req) => {
 
             await checkPermissions()
 
-            let [ , package_name, version ] = req.body.issue.title.match(/^(\S+): update to (\S+)/) || []
-            if (!package_name || !version) throw new Error(`Could not parse ${req.issue.title} in ${commentURL}`)
-            if (package_name == 'git-lfs') package_name = `mingw-w64-${package_name}`
-            if (version.startsWith('v')) version = version.substring(1)
+            const { guessComponentUpdateDetails } = require('./component-updates')
+            const { package_name } = guessComponentUpdateDetails(req.body.issue.title, req.body.issue.body)
 
             // The commit hash of the tip commit is sadly not part of the
             // "comment.created" webhook's payload. Therefore, we have to get it


### PR DESCRIPTION
[I noticed this morning](https://github.com/git-for-windows/MSYS2-packages/pull/70#issuecomment-1357489945) that `git-sdk-32` unexpectedly failed to update MinTTY to v3.6.3, and figured out that it was simply an oversight on my part in forgetting to implement the `/deploy` side of MSYS packages' builds, and therefore only the x86_64 package was built (and that one quite by happy mistake).

This PR introduces support for `/deploy`ing MSYS packages (the `git-for-windows-automation` workflow was [already prepared for it in advance](https://github.com/git-for-windows/git-for-windows-automation/commit/349e4e17451b3a8be428e8f81a62f57db7620efa).