### PR TITLE
/deploy: populate Details URL

### DIFF
--- a/GitForWindowsHelper/check-runs.js
+++ b/GitForWindowsHelper/check-runs.js
@@ -47,6 +47,20 @@ const queueCheckRun = async (context, token, owner, repo, ref, checkRunName, tit
     return id
   }
 
+  const updateCheckRun = async (context, token, owner, repo, checkRunId, parameters) => {
+    const githubApiRequest = require('./github-api-request')
+
+      await githubApiRequest(
+      context,
+      token,
+      'PATCH',
+      `/repos/${owner}/${repo}/check-runs/${checkRunId}`, 
+      parameters
+      }
+    )
+  }
+
   module.exports = {
-    queueCheckRun
+    queueCheckRun,
+    updateCheckRun
   }

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -162,7 +162,7 @@ module.exports = async (context, req) => {
                     text
                 )
             if (!isMSYSPackage(package_name)) {
-                await queueCheckRun(
+                const id = await queueCheckRun(
                     context,
                     await getToken(),
                     'git-for-windows',
@@ -175,10 +175,19 @@ module.exports = async (context, req) => {
 
                 const answer = await triggerBuild()
                 const answer2 = await appendToComment(`The workflow run [was started](${answer.html_url})`)
+                await updateCheckRun(
+                    context,
+                    await getToken(),
+                    'git-for-windows',
+                    repo,
+                    id, {
+                        details_url: answer.html_url
+                    }
+                )
                 return `I edited the comment: ${answer2.html_url}`
             }
             
-            await queueCheckRun(
+            const x86_64Id = await queueCheckRun(
                 context,
                 await getToken(),
                 'git-for-windows',
@@ -188,7 +197,7 @@ module.exports = async (context, req) => {
                 `Build and deploy ${package_name}`,
                 `Deploying ${package_name}`
             )
-            await queueCheckRun(
+            const i686Id = await queueCheckRun(
                 context,
                 await getToken(),
                 'git-for-windows',
@@ -203,6 +212,24 @@ module.exports = async (context, req) => {
             const i686Answer = await triggerBuild('i686')
             const answer2 = await appendToComment(
                 `The [x86_64](${x86_64Answer.html_url}) and the [i686](${i686Answer.html_url}) workflow runs were started.`
+            )
+            await updateCheckRun(
+                context,
+                await getToken(),
+                'git-for-windows',
+                repo,
+                x86_64Id, {
+                    details_url: x86_64Answer.html_url
+                }
+            )
+            await updateCheckRun(
+                context,
+                await getToken(),
+                'git-for-windows',
+                repo,
+                i686Id, {
+                    details_url: i686Answer.html_url
+                }
             )
             return `I edited the comment: ${answer2.html_url}`
         }

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -134,17 +134,6 @@ module.exports = async (context, req) => {
             await thumbsUp()
 
             const { queueCheckRun } = require('./check-runs')
-            await queueCheckRun(
-                context,
-                await getToken(),
-                'git-for-windows',
-                repo,
-                ref,
-                'deploy',
-                `Build and deploy ${package_name}`,
-                `Deploying ${package_name}`
-            )
-
             const triggerWorkflowDispatch = require('./trigger-workflow-dispatch')
             const triggerBuild = async (architecture) =>
                 await triggerWorkflowDispatch(
@@ -173,10 +162,43 @@ module.exports = async (context, req) => {
                     text
                 )
             if (!isMSYSPackage(package_name)) {
+                await queueCheckRun(
+                    context,
+                    await getToken(),
+                    'git-for-windows',
+                    repo,
+                    ref,
+                    'deploy',
+                    `Build and deploy ${package_name}`,
+                    `Deploying ${package_name}`
+                )
+
                 const answer = await triggerBuild()
                 const answer2 = await appendToComment(`The workflow run [was started](${answer.html_url})`)
                 return `I edited the comment: ${answer2.html_url}`
             }
+            
+            await queueCheckRun(
+                context,
+                await getToken(),
+                'git-for-windows',
+                repo,
+                ref,
+                'deploy_x86_64',
+                `Build and deploy ${package_name}`,
+                `Deploying ${package_name}`
+            )
+            await queueCheckRun(
+                context,
+                await getToken(),
+                'git-for-windows',
+                repo,
+                ref,
+                'deploy_i686',
+                `Build and deploy ${package_name}`,
+                `Deploying ${package_name}`
+            )
+            
             const x86_64Answer = await triggerBuild('x86_64')
             const i686Answer = await triggerBuild('i686')
             const answer2 = await appendToComment(


### PR DESCRIPTION
GitHubs check runs provide a neat little "view more details" link (see for example https://github.com/git-for-windows/build-extra/pull/451/checks?check_run_id=10110786774) That should allow users to view the status of the check run (beyond running/queued/success/failure). For our check runs it currently just links to https://github.com/git-for-windows/gfw-helper-github-app, but we can populate the URL to link to the actual workflow run we're waiting for.