### PR TITLE
Automatically spin up/tear down self-hosted ARM64 runners

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,5 +7,8 @@
   "parserOptions": {
     "ecmaVersion": 12,
     "sourceType": "module"
+  },
+  "rules": {
+    "indent": ["error", 4]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
     "sourceType": "module"
   },
   "rules": {
-    "indent": ["error", 4]
+    "indent": ["error", 4],
+    "no-trailing-spaces": "error"
   }
 }

--- a/GitForWindowsHelper/azure-pipelines.js
+++ b/GitForWindowsHelper/azure-pipelines.js
@@ -79,24 +79,24 @@ const getRelease = async (context, token, organization, project, releaseId) => {
 }
 
 const createRelease = async (
-  context,
-  token,
-  organization,
-  project,
-  releaseDefinitionId,
-  artifactAlias,
-  artifactBuildRunId,
-  artifactBuildRunName,
-  artifactBuildDefinitionId,
-  artifactBuildDefinitionName,
-  sourceBranch,
-  sourceCommitId,
-  repo
+    context,
+    token,
+    organization,
+    project,
+    releaseDefinitionId,
+    artifactAlias,
+    artifactBuildRunId,
+    artifactBuildRunName,
+    artifactBuildDefinitionId,
+    artifactBuildDefinitionName,
+    sourceBranch,
+    sourceCommitId,
+    repo
 ) => {
     const auth = Buffer.from("PAT:" + token).toString("base64");
     const headers = {
-      Accept: "application/json; api-version=7.0; excludeUrls=true",
-      Authorization: "Basic " + auth,
+        Accept: "application/json; api-version=7.0; excludeUrls=true",
+        Authorization: "Basic " + auth,
     };
     const body = {
         definitionId: releaseDefinitionId,
@@ -157,19 +157,19 @@ const releaseGitArtifacts = async (context, prNumber) => {
 
     const token = process.env['AZURE_PIPELINE_TRIGGER_TOKEN']
     const answer2 = await createRelease(
-      context,
-      token,
-      'git-for-windows',
-      'git',
-      1,
-      'artifacts',
-      artifactBuildRunId,
-      artifactBuildRunName,
-      artifactBuildDefinitionId,
-      artifactBuildDefinitionName,
-      sourceBranch,
-      sourceCommitId,
-      'git-for-windows/git'
+        context,
+        token,
+        'git-for-windows',
+        'git',
+        1,
+        'artifacts',
+        artifactBuildRunId,
+        artifactBuildRunName,
+        artifactBuildDefinitionId,
+        artifactBuildDefinitionName,
+        sourceBranch,
+        sourceCommitId,
+        'git-for-windows/git'
     )
     return {
         id: answer2.id,

--- a/GitForWindowsHelper/check-runs.js
+++ b/GitForWindowsHelper/check-runs.js
@@ -59,7 +59,20 @@ const updateCheckRun = async (context, token, owner, repo, checkRunId, parameter
     )
 }
 
+const cancelWorkflowRun = async (context, token, owner, repo, workflowRunId) => {
+    const githubApiRequest = require('./github-api-request')
+
+    const answer = await githubApiRequest(
+        context,
+        token,
+        'POST',
+        `/repos/${owner}/${repo}/actions/runs/${workflowRunId}/cancel`
+    )
+    console.log(answer)
+}
+
 module.exports = {
     queueCheckRun,
-    updateCheckRun
+    updateCheckRun,
+    cancelWorkflowRun
 }

--- a/GitForWindowsHelper/check-runs.js
+++ b/GitForWindowsHelper/check-runs.js
@@ -2,64 +2,64 @@ const queueCheckRun = async (context, token, owner, repo, ref, checkRunName, tit
     const githubApiRequest = require('./github-api-request')
     // is there an existing check-run we can re-use?
     const { check_runs } = await githubApiRequest(
-      context,
-      token,
-      'GET',
-      `/repos/${owner}/${repo}/commits/${ref}/check-runs`
+        context,
+        token,
+        'GET',
+        `/repos/${owner}/${repo}/commits/${ref}/check-runs`
     )
     const filtered = check_runs
-      .filter(e => e.name === checkRunName && e.conclusion === null).map(e => {
-        return {
-          id: e.id,
-          status: e.status
-        }
-      })
+        .filter(e => e.name === checkRunName && e.conclusion === null).map(e => {
+            return {
+                id: e.id,
+                status: e.status
+            }
+        })
     if (filtered.length > 0) {
-      // ensure that the check_run is set to status "in progress"
-      if (filtered[0].status !== 'queued') {
-        console.log(await githubApiRequest(
-          context,
-          token,
-          'PATCH',
-          `/repos/${owner}/${repo}/check-runs/${filtered[0].id}`, {
-            status: 'queued'
-          }
-        ))
-      }
-      process.stderr.write(`Returning existing ${filtered[0].id}`)
-      return filtered[0].id
+        // ensure that the check_run is set to status "in progress"
+        if (filtered[0].status !== 'queued') {
+            console.log(await githubApiRequest(
+                context,
+                token,
+                'PATCH',
+                `/repos/${owner}/${repo}/check-runs/${filtered[0].id}`, {
+                    status: 'queued'
+                }
+            ))
+        }
+        process.stderr.write(`Returning existing ${filtered[0].id}`)
+        return filtered[0].id
     }
 
     const { id } = await githubApiRequest(
-      context,
-      token,
-      'POST',
-      `/repos/${owner}/${repo}/check-runs`, {
-        name: checkRunName,
-        head_sha: ref,
-        status: 'queued',
-        output: {
-          title,
-          summary
+        context,
+        token,
+        'POST',
+        `/repos/${owner}/${repo}/check-runs`, {
+            name: checkRunName,
+            head_sha: ref,
+            status: 'queued',
+            output: {
+                title,
+                summary
+            }
         }
-      }
     )
     return id
-  }
+}
 
-  const updateCheckRun = async (context, token, owner, repo, checkRunId, parameters) => {
+const updateCheckRun = async (context, token, owner, repo, checkRunId, parameters) => {
     const githubApiRequest = require('./github-api-request')
 
-      await githubApiRequest(
-      context,
-      token,
-      'PATCH',
-      `/repos/${owner}/${repo}/check-runs/${checkRunId}`, 
-      parameters
+    await githubApiRequest(
+        context,
+        token,
+        'PATCH',
+        `/repos/${owner}/${repo}/check-runs/${checkRunId}`, 
+        parameters
     )
-  }
+}
 
-  module.exports = {
+module.exports = {
     queueCheckRun,
     updateCheckRun
-  }
+}

--- a/GitForWindowsHelper/check-runs.js
+++ b/GitForWindowsHelper/check-runs.js
@@ -54,7 +54,7 @@ const updateCheckRun = async (context, token, owner, repo, checkRunId, parameter
         context,
         token,
         'PATCH',
-        `/repos/${owner}/${repo}/check-runs/${checkRunId}`, 
+        `/repos/${owner}/${repo}/check-runs/${checkRunId}`,
         parameters
     )
 }

--- a/GitForWindowsHelper/get-collaborator-permissions.js
+++ b/GitForWindowsHelper/get-collaborator-permissions.js
@@ -1,13 +1,13 @@
 // Gets the permission level of a collaborator on the specified repository
 // Returns `ADMIN`, `MAINTAIN`, `READ`, `TRIAGE` or `WRITE`.
 module.exports = async (context, token, owner, repo, collaborator) => {
-  const gitHubAPIRequest = require('./github-api-request')
-  const answer = await gitHubAPIRequest(
-    context,
-    token,
-    'POST',
-    '/graphql', {
-      query: `query CollaboratorPermission($owner: String!, $repo: String!, $collaborator: String) {
+    const gitHubAPIRequest = require('./github-api-request')
+    const answer = await gitHubAPIRequest(
+        context,
+        token,
+        'POST',
+        '/graphql', {
+            query: `query CollaboratorPermission($owner: String!, $repo: String!, $collaborator: String) {
         repository(owner:$owner, name:$repo) {
           collaborators(query: $collaborator) {
             edges {
@@ -16,13 +16,13 @@ module.exports = async (context, token, owner, repo, collaborator) => {
           }
         }
       }`,
-      variables: {
-        owner,
-        repo,
-        collaborator
-      }
-    }
-  )
-  if (answer.error) throw answer.error
-  return answer.data.repository.collaborators.edges.map(e => e.permission.toString())
+            variables: {
+                owner,
+                repo,
+                collaborator
+            }
+        }
+    )
+    if (answer.error) throw answer.error
+    return answer.data.repository.collaborators.edges.map(e => e.permission.toString())
 }

--- a/GitForWindowsHelper/github-api-request-as-app.js
+++ b/GitForWindowsHelper/github-api-request-as-app.js
@@ -16,7 +16,7 @@ module.exports = async (context, requestMethod, requestPath, body) => {
     }
 
     const toBase64 = (obj) => Buffer.from(JSON.stringify(obj), "utf-8").toString("base64url")
-	const headerAndPayload = `${toBase64(header)}.${toBase64(payload)}`
+    const headerAndPayload = `${toBase64(header)}.${toBase64(payload)}`
 
     const privateKey = `-----BEGIN RSA PRIVATE KEY-----\n${process.env['GITHUB_APP_PRIVATE_KEY']}\n-----END RSA PRIVATE KEY-----\n`
 

--- a/GitForWindowsHelper/https-request.js
+++ b/GitForWindowsHelper/https-request.js
@@ -28,7 +28,7 @@ module.exports = async (context, hostname, method, requestPath, body, headers) =
                     statusCode: res.statusCode,
                     statusMessage: res.statusMessage,
                     headers: res.headers
-                 })
+                })
 
                 const chunks = []
                 res.on('data', data => chunks.push(data))

--- a/GitForWindowsHelper/index.js
+++ b/GitForWindowsHelper/index.js
@@ -31,6 +31,19 @@ module.exports = async function (context, req) {
         return withStatus(500, undefined, e.toString('utf-8'))
     }
 
+    try {
+        const selfHostedARM64Runners = require('./self-hosted-arm64-runners')
+        if (req.headers['x-github-event'] === 'workflow_job'
+            && req.body.repository.full_name === 'git-for-windows/git-for-windows-automation'
+            && ['queued', 'completed'].includes(req.body.action)
+            && req.body.workflow_job.labels.length === 2
+            && req.body.workflow_job.labels[0] === 'Windows'
+            && req.body.workflow_job.labels[1] === 'ARM64') return ok(await selfHostedARM64Runners(context, req))
+    } catch (e) {
+        context.log(e)
+        return withStatus(500, undefined, e.toString('utf-8'))
+    }
+
     context.log("Got headers")
     context.log(req.headers)
     context.log("Got body")

--- a/GitForWindowsHelper/self-hosted-arm64-runners.js
+++ b/GitForWindowsHelper/self-hosted-arm64-runners.js
@@ -35,5 +35,23 @@ module.exports = async (context, req) => {
         throw new Error(`${sender} is not allowed to do that`)
     }
 
+    if (action === 'queued') {
+        // Spin up a new runner
+        const triggerWorkflowDispatch = require('./trigger-workflow-dispatch')
+        const token = await getToken()
+        const answer = await triggerWorkflowDispatch(
+            context,
+            token,
+            'git-for-windows',
+            'git-for-windows-automation',
+            'create-azure-self-hosted-runners.yml',
+            'main', {
+                runner_scope: 'repo-level'
+            }
+        )
+
+        return `The workflow run to create the self-hosted runner VM was started at ${answer.html_url}`
+    }
+
     return `Unhandled action: ${action}`
 }

--- a/GitForWindowsHelper/self-hosted-arm64-runners.js
+++ b/GitForWindowsHelper/self-hosted-arm64-runners.js
@@ -1,0 +1,39 @@
+module.exports = async (context, req) => {
+    const action = req.body.action
+    const owner = req.body.repository.owner.login
+    const repo = req.body.repository.name
+    const sender = req.body.sender.login
+
+    const getToken = (() => {
+        let token
+
+        const get = async () => {
+            const getInstallationIdForRepo = require('./get-installation-id-for-repo')
+            const installationId = await getInstallationIdForRepo(context, owner, repo)
+            const getInstallationAccessToken = require('./get-installation-access-token')
+            return await getInstallationAccessToken(context, installationId)
+        }
+
+        return async () => token || (token = await get())
+    })()
+
+    const isAllowed = async (login) => {
+        const getCollaboratorPermissions = require('./get-collaborator-permissions')
+        const token = await getToken()
+        const permission = await getCollaboratorPermissions(context, token, owner, repo, login)
+        return ['ADMIN', 'MAINTAIN', 'WRITE'].includes(permission.toString())
+    }
+
+    if (!isAllowed(sender)) {
+        if (action !== 'completed') {
+            // Cancel workflow run
+            const { cancelWorkflowRun } = require('./check-runs')
+            const token = await getToken()
+            const workflowRunId = req.body.workflow_job.run_id
+            await cancelWorkflowRun(context, token, owner, repo, workflowRunId)
+        }
+        throw new Error(`${sender} is not allowed to do that`)
+    }
+
+    return `Unhandled action: ${action}`
+}

--- a/GitForWindowsHelper/self-hosted-arm64-runners.js
+++ b/GitForWindowsHelper/self-hosted-arm64-runners.js
@@ -53,5 +53,24 @@ module.exports = async (context, req) => {
         return `The workflow run to create the self-hosted runner VM was started at ${answer.html_url}`
     }
 
+    if (action === 'completed') {
+        // Delete the runner
+        const triggerWorkflowDispatch = require('./trigger-workflow-dispatch')
+        const token = await getToken()
+        const vmName = req.body.workflow_job.runner_name
+        const answer = await triggerWorkflowDispatch(
+            context,
+            token,
+            'git-for-windows',
+            'git-for-windows-automation',
+            'delete-self-hosted-runner.yml',
+            'main', {
+                runner_name: vmName
+            }
+        )
+
+        return `The workflow run to delete the self-hosted runner VM '${vmName}' was started at ${answer.html_url}`
+    }
+
     return `Unhandled action: ${action}`
 }

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -69,14 +69,14 @@ module.exports = async (context, req) => {
                 if (alreadyOpenedPR.length > 0) {
                     ({ html_url: commentURL, id: commentId } =
                       await appendToIssueComment(
-                        context,
-                        await getToken(),
-                        owner,
-                        repo,
-                        commentId,
-                        `${
-                          packageType ? `${packageType} ` : ""
-                        }PR [already exists](${alreadyOpenedPR[0].html_url})`
+                          context,
+                          await getToken(),
+                          owner,
+                          repo,
+                          commentId,
+                          `${
+                              packageType ? `${packageType} ` : ""
+                          }PR [already exists](${alreadyOpenedPR[0].html_url})`
                       ));
                     return
                 }
@@ -111,14 +111,14 @@ module.exports = async (context, req) => {
              || !req.body.issue.pull_request
              || !['build-extra', 'MINGW-packages', 'MSYS2-packages'].includes(repo)) {
                 return `Ignoring ${command} in unexpected repo: ${commentURL}`
-             }
+            }
 
             await checkPermissions()
 
             const { guessComponentUpdateDetails, isMSYSPackage } = require('./component-updates')
             const { package_name } = deployMatch[2]
-                 ? { package_name: deployMatch[2] }
-                 : guessComponentUpdateDetails(req.body.issue.title, req.body.issue.body)
+                ? { package_name: deployMatch[2] }
+                : guessComponentUpdateDetails(req.body.issue.title, req.body.issue.body)
 
             // The commit hash of the tip commit is sadly not part of the
             // "comment.created" webhook's payload. Therefore, we have to get it
@@ -238,9 +238,9 @@ module.exports = async (context, req) => {
             if (owner !== 'git-for-windows'
              || repo !== 'git'
              || !req.body.issue.pull_request
-             ) {
+            ) {
                 return `Ignoring ${command} in unexpected repo: ${commentURL}`
-             }
+            }
 
             await checkPermissions()
             await thumbsUp()
@@ -255,11 +255,11 @@ module.exports = async (context, req) => {
 
         if (command == '/release') {
             if (owner !== 'git-for-windows'
-             || repo !== 'git'
-             || !req.body.issue.pull_request
-             ) {
+              || repo !== 'git'
+              || !req.body.issue.pull_request
+            ) {
                 return `Ignoring ${command} in unexpected repo: ${commentURL}`
-             }
+            }
 
             await checkPermissions()
             await thumbsUp()
@@ -277,7 +277,7 @@ module.exports = async (context, req) => {
             if (owner !== 'git-for-windows'
              || !['git', 'build-extra', 'MINGW-packages', 'MSYS2-packages'].includes(repo)) {
                 return `Ignoring ${command} in unexpected repo: ${commentURL}`
-             }
+            }
 
             await checkPermissions()
 

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -186,7 +186,7 @@ module.exports = async (context, req) => {
                 )
                 return `I edited the comment: ${answer2.html_url}`
             }
-            
+
             const x86_64Id = await queueCheckRun(
                 context,
                 await getToken(),
@@ -207,7 +207,7 @@ module.exports = async (context, req) => {
                 `Build and deploy ${package_name}`,
                 `Deploying ${package_name}`
             )
-            
+
             const x86_64Answer = await triggerBuild('x86_64')
             const i686Answer = await triggerBuild('i686')
             const answer2 = await appendToComment(

--- a/GitForWindowsHelper/trigger-workflow-dispatch.js
+++ b/GitForWindowsHelper/trigger-workflow-dispatch.js
@@ -2,50 +2,50 @@ const githubApiRequest = require('./github-api-request')
 const githubApiRequestAsApp = require('./github-api-request-as-app')
 
 const sleep = async (milliseconds) => {
-  return new Promise((resolve) => {
-    setTimeout(resolve, milliseconds)
-  })
+    return new Promise((resolve) => {
+        setTimeout(resolve, milliseconds)
+    })
 }
 
 const getActorForToken = async (context, token) => {
-  try {
-    const { login } = await githubApiRequest(context, token, 'GET', '/user')
-    return login
-  } catch (e) {
-    if (e.statusCode !== 403 || e.json?.message !== 'Resource not accessible by integration') throw e
-    const answer = await githubApiRequestAsApp(context, 'GET', '/app')
-    return `${answer.slug}[bot]`
-  }
+    try {
+        const { login } = await githubApiRequest(context, token, 'GET', '/user')
+        return login
+    } catch (e) {
+        if (e.statusCode !== 403 || e.json?.message !== 'Resource not accessible by integration') throw e
+        const answer = await githubApiRequestAsApp(context, 'GET', '/app')
+        return `${answer.slug}[bot]`
+    }
 }
 
 const waitForWorkflowRun = async (context, owner, repo, workflow_id, after, token, actor) => {
-  if (!actor) actor = await getActorForToken(context, token)
-  let counter = 0
-  for (;;) {
-    const res = await githubApiRequest(
-      context,
-      token,
-      'GET',
-      `/repos/${owner}/${repo}/actions/runs?actor=${actor}&event=workflow_dispatch&created=>${after}`
-    )
-    const filtered = res.workflow_runs.filter(e => e.path === `.github/workflows/${workflow_id}`)
-    if (filtered.length > 0) return filtered
-    if (counter++ > 30) throw new Error(`Times out waiting for workflow?`)
-    await sleep(1000)
-  }
+    if (!actor) actor = await getActorForToken(context, token)
+    let counter = 0
+    for (;;) {
+        const res = await githubApiRequest(
+            context,
+            token,
+            'GET',
+            `/repos/${owner}/${repo}/actions/runs?actor=${actor}&event=workflow_dispatch&created=>${after}`
+        )
+        const filtered = res.workflow_runs.filter(e => e.path === `.github/workflows/${workflow_id}`)
+        if (filtered.length > 0) return filtered
+        if (counter++ > 30) throw new Error(`Times out waiting for workflow?`)
+        await sleep(1000)
+    }
 }
 
 const triggerWorkflowDispatch = async (context, token, owner, repo, workflow_id, ref, inputs) => {
-  const { headers: { date } } = await githubApiRequest(
-    context,
-    token,
-    'POST',
-    `/repos/${owner}/${repo}/actions/workflows/${workflow_id}/dispatches`,
-    { ref, inputs }
-  )
+    const { headers: { date } } = await githubApiRequest(
+        context,
+        token,
+        'POST',
+        `/repos/${owner}/${repo}/actions/workflows/${workflow_id}/dispatches`,
+        { ref, inputs }
+    )
 
-  const runs = await waitForWorkflowRun(context, owner, repo, workflow_id, new Date(date).toISOString(), token)
-  return runs[0]
+    const runs = await waitForWorkflowRun(context, owner, repo, workflow_id, new Date(date).toISOString(), token)
+    return runs[0]
 }
 
 module.exports = triggerWorkflowDispatch


### PR DESCRIPTION
With these changes (that require https://github.com/git-for-windows/git-for-windows-automation/pull/11 to be merged first), we will have automation in place where starting a workflow job in `git-for-windows/git-for-windows-automation` that requires an ARM64 runner will automatically spin up the required runner and delete the VM after use.

NOTE: This is not yet fully tested, I basically only verified that [an unauthorized build can be successfully canceled](https://github.com/git-for-windows/git-for-windows-automation/pull/13) (I patched the code locally to pretend that I am not authorized). I plan on fully testing this later, using [the `mingw-w64-clang-aarch64-xpdf` build](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/3881130673) to trigger said workflow job, and simulating the App locally based on the captured event payloads.