### PR TITLE
/open pr: handle multiple underscores in the reported version

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -12,7 +12,8 @@ const guessComponentUpdateDetails = (title, body) => {
 
     version = version
         .replace(/^(GCM |openssl-|OpenSSL_|v|V_|GnuTLS |tig-|Heimdal |cygwin-|PCRE2-|Bash-)/, '')
-        .replace(/_|\s+patch\s+/, '.')
+        .replace(/\s+patch\s+/, '.')
+        .replace(/_/g, '.')
         .replace(/-release$/, '')
 
     return { package_name, version }

--- a/test-open-pr.js
+++ b/test-open-pr.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+(async () => {
+    // Expect a URL
+    const url = process.argv[2]
+    const match = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)\/?$/)
+    if (!match) throw new Error(`Unhandled URL: ${url}`)
+    const [, owner, repo, number ] = match
+
+    const githubApiRequest = require('./GitForWindowsHelper/github-api-request')
+    const { title, body } = await githubApiRequest(
+        console,
+        null,
+        'GET',
+        `/repos/${owner}/${repo}/issues/${number}`
+    )
+
+    const { guessComponentUpdateDetails } = require('./GitForWindowsHelper/component-updates')
+    const details = await guessComponentUpdateDetails(title, body)
+    console.log(details)
+})().catch(console.log)

--- a/test-pr-comment-delivery.js
+++ b/test-pr-comment-delivery.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 (async () => {
     const fs = require('fs')
 


### PR DESCRIPTION
Seems that even [if OpenSSL re-announced their version with dots in the version string](https://github.com/git-for-windows/git/issues/4277#issuecomment-1422243185) that we mishandled version strings with multiple underscores.

Let's fix that.