### PR TITLE
Improve the logic to guess release notes in `/add release note`

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -58,7 +58,9 @@ const guessReleaseNotes = (issue) => {
     package_name = prettyPackageName(package_name.replace(/^mingw-w64-/, ''))
 
     const matchURLInIssue = (issue) => {
-        const match = issue.body.match(/(?:^|\n)(https:\/\/\S+)$/)
+        const match = issue.body.match(package_name.toLowerCase() === 'bash'
+            ? /(?:^|\n)(https:\/\/\S+)/ // for `bash`, use the first URL
+            : /(?:^|\n)(https:\/\/\S+)$/)
         return match && match[1]
     }
 

--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -53,7 +53,7 @@ const needsSeparateARM64Build = package_name => {
 const guessReleaseNotes = (issue) => {
     if (!issue.pull_request
         &&issue.labels.filter(label => label.name === 'component-update').length !== 1) throw new Error(`Cannot determine release note from issue ${issue.number}`)
-    let { package_name, version } = guessComponentUpdateDetails(issue.title)
+    let { package_name, version } = guessComponentUpdateDetails(issue.title, issue.body)
 
     package_name = prettyPackageName(package_name.replace(/^mingw-w64-/, ''))
 

--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -50,7 +50,7 @@ const needsSeparateARM64Build = package_name => {
     ].includes(package_name)
 }
 
-const guessReleaseNotes = (issue) => {
+const guessReleaseNotes = async (context, issue) => {
     if (!issue.pull_request
         &&issue.labels.filter(label => label.name === 'component-update').length !== 1) throw new Error(`Cannot determine release note from issue ${issue.number}`)
     let { package_name, version } = guessComponentUpdateDetails(issue.title, issue.body)
@@ -69,6 +69,18 @@ const guessReleaseNotes = (issue) => {
 
         const match = issue.body.match(/See (https:\/\/\S+) for details/)
         if (match) return match[1]
+
+        const issueMatch = issue.body.match(/https:\/\/github\.com\/git-for-windows\/git\/issues\/(\d+)/)
+        if (issueMatch) {
+            const githubApiRequest = require('./github-api-request')
+            const issue = await githubApiRequest(
+                context,
+                null,
+                'GET',
+                `/repos/git-for-windows/git/issues/${issueMatch[1]}`
+            )
+            return matchURLInIssue(issue)
+        }
     }
 
     const url = await matchURL()

--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -57,13 +57,23 @@ const guessReleaseNotes = (issue) => {
 
     package_name = prettyPackageName(package_name.replace(/^mingw-w64-/, ''))
 
-    const urlMatch = issue.pull_request
-        ? issue.body.match(/See (https:\/\/\S+) for details/)
-        : issue.body.match(/(?:^|\n)(https:\/\/\S+)$/)
-    if (!urlMatch) throw new Error(`Could not determine URL from issue ${issue.number}`)
+    const matchURLInIssue = (issue) => {
+        const match = issue.body.match(/(?:^|\n)(https:\/\/\S+)$/)
+        return match && match[1]
+    }
+
+    const matchURL = async () => {
+        if (!issue.pull_request) return matchURLInIssue(issue)
+
+        const match = issue.body.match(/See (https:\/\/\S+) for details/)
+        if (match) return match[1]
+    }
+
+    const url = await matchURL()
+    if (!url) throw new Error(`Could not determine URL from issue ${issue.number}`)
     return {
         type: 'feature',
-        message: `Comes with [${package_name} v${version}](${urlMatch[1]}).`
+        message: `Comes with [${package_name} v${version}](${url}).`
     }
 }
 

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -311,7 +311,7 @@ module.exports = async (context, req) => {
             let [ , , , type, message ] = relNotesMatch
             if (!type) {
                 const { guessReleaseNotes } = require('./component-updates');
-                ({ type, message } = await guessReleaseNotes(req.body.issue))
+                ({ type, message } = await guessReleaseNotes(context, req.body.issue))
             }
 
             await thumbsUp()

--- a/test-guess-relnote.js
+++ b/test-guess-relnote.js
@@ -16,6 +16,6 @@
     )
 
     const { guessReleaseNotes } = require('./GitForWindowsHelper/component-updates')
-    const guessed = await guessReleaseNotes(issue)
+    const guessed = await guessReleaseNotes(console, issue)
     console.log(JSON.stringify(guessed, null, 2))
 })().catch(console.log)

--- a/test-guess-relnote.js
+++ b/test-guess-relnote.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+(async () => {
+    // Expect a URL
+    const url = process.argv[2]
+    const match = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/(?:issues|pulls?)\/(\d+)\/?$/)
+    if (!match) throw new Error(`Unhandled URL: ${url}`)
+    const [, owner, repo, number ] = match
+
+    const githubApiRequest = require('./GitForWindowsHelper/github-api-request')
+    const issue = await githubApiRequest(
+        console,
+        null,
+        'GET',
+        `/repos/${owner}/${repo}/issues/${number}`
+    )
+
+    const { guessReleaseNotes } = require('./GitForWindowsHelper/component-updates')
+    const guessed = await guessReleaseNotes(issue)
+    console.log(JSON.stringify(guessed, null, 2))
+})().catch(console.log)


### PR DESCRIPTION
When issuing an `/add release note` without any further information, we try to auto-generate a sensible message from the context.

While looking into adding a release note for Bash in https://github.com/git-for-windows/git/issues/4164, I realized that that logic is pretty much failing completely for that package.

Here is my attempt to fix that.