### PR TITLE
Switch `/git-artifacts` and `/release` to trigger GitHub workflows instead

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,17 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Tests",
+      "program": "${workspaceRoot}/node_modules/.bin/jest",
+      "cwd": "${workspaceRoot}",
+      "args": ["--runInBand", "--config", "jest.config.js"],
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    },
+    {
       "name": "Attach to Node Functions",
       "type": "node",
       "request": "attach",

--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -11,30 +11,30 @@ const getToken = (() => {
     return async (context, owner, repo) => tokens[[owner, repo]] || (tokens[[owner, repo]] = await get(context, owner, repo))
 })()
 
-const triggerGitArtifactsRuns = async (context, checkRunOwner, checkRunRepo, checkRun) => {
-    const commitSHA = checkRun.head_sha
-    const conclusion = checkRun.conclusion
-    const text = checkRun.output.text
+const triggerGitArtifactsRuns = async (context, checkRunOwner, checkRunRepo, tagGitCheckRun) => {
+    const commitSHA = tagGitCheckRun.head_sha
+    const conclusion = tagGitCheckRun.conclusion
+    const text = tagGitCheckRun.output.text
 
     if (conclusion !== 'success') {
-        throw new Error(`tag-git run ${checkRun.id} completed with ${conclusion}: ${checkRun.html_url}`)
+        throw new Error(`tag-git run ${tagGitCheckRun.id} completed with ${conclusion}: ${tagGitCheckRun.html_url}`)
     }
 
     const match = text.match(/For details, see \[this run\]\(https:\/\/github.com\/([^/]+)\/([^/]+)\/actions\/runs\/(\d+)\)/)
-    if (!match) throw new Error(`Unhandled 'text' attribute of tag-git run ${checkRun.id}: ${checkRun.url}`)
+    if (!match) throw new Error(`Unhandled 'text' attribute of tag-git run ${tagGitCheckRun.id}: ${tagGitCheckRun.url}`)
     const owner = match[1]
     const repo = match[2]
     const workflowRunId = Number(match[3])
     if (owner !== 'git-for-windows' || repo !== 'git-for-windows-automation') {
-        throw new Error(`Unexpected repository ${owner}/${repo} for tag-git run ${checkRun.id}: ${checkRun.url}`)
+        throw new Error(`Unexpected repository ${owner}/${repo} for tag-git run ${tagGitCheckRun.id}: ${tagGitCheckRun.url}`)
     }
 
-    const gitVersionMatch = checkRun.output.summary.match(/^Tag Git (\S+) @([0-9a-f]+)$/)
+    const gitVersionMatch = tagGitCheckRun.output.summary.match(/^Tag Git (\S+) @([0-9a-f]+)$/)
     if (!gitVersionMatch) {
-        throw new Error(`Could not parse Git version from summary '${checkRun.output.summary}' of tag-git run ${checkRun.id}: ${checkRun.url}`)
+        throw new Error(`Could not parse Git version from summary '${tagGitCheckRun.output.summary}' of tag-git run ${tagGitCheckRun.id}: ${tagGitCheckRun.url}`)
     }
     if (commitSHA !== gitVersionMatch[2]) {
-        throw new Error(`Expected ${commitSHA} in summary '${checkRun.output.summary}' of tag-git run ${checkRun.id}: ${checkRun.url}`)
+        throw new Error(`Expected ${commitSHA} in summary '${tagGitCheckRun.output.summary}' of tag-git run ${tagGitCheckRun.id}: ${tagGitCheckRun.url}`)
     }
     const gitVersion = gitVersionMatch[1]
 

--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -1,25 +1,112 @@
-module.exports = async (context, req) => {
+const getToken = (() => {
+    const tokens = {}
+
+    const get = async (context, owner, repo) => {
+        const getInstallationIdForRepo = require('./get-installation-id-for-repo')
+        const installationId = await getInstallationIdForRepo(context, owner, repo)
+        const getInstallationAccessToken = require('./get-installation-access-token')
+        return await getInstallationAccessToken(context, installationId)
+    }
+
+    return async (context, owner, repo) => tokens[[owner, repo]] || (tokens[[owner, repo]] = await get(context, owner, repo))
+})()
+
+const triggerGitArtifactsRuns = async (context, checkRunOwner, checkRunRepo, checkRun) => {
+    const commitSHA = checkRun.head_sha
+    const conclusion = checkRun.conclusion
+    const text = checkRun.output.text
+
+    if (conclusion !== 'success') {
+        throw new Error(`tag-git run ${checkRun.id} completed with ${conclusion}: ${checkRun.html_url}`)
+    }
+
+    const match = text.match(/For details, see \[this run\]\(https:\/\/github.com\/([^/]+)\/([^/]+)\/actions\/runs\/(\d+)\)/)
+    if (!match) throw new Error(`Unhandled 'text' attribute of tag-git run ${checkRun.id}: ${checkRun.url}`)
+    const owner = match[1]
+    const repo = match[2]
+    const workflowRunId = Number(match[3])
+    if (owner !== 'git-for-windows' || repo !== 'git-for-windows-automation') {
+        throw new Error(`Unexpected repository ${owner}/${repo} for tag-git run ${checkRun.id}: ${checkRun.url}`)
+    }
+
+    const gitVersionMatch = checkRun.output.summary.match(/^Tag Git (\S+) @([0-9a-f]+)$/)
+    if (!gitVersionMatch) {
+        throw new Error(`Could not parse Git version from summary '${checkRun.output.summary}' of tag-git run ${checkRun.id}: ${checkRun.url}`)
+    }
+    if (commitSHA !== gitVersionMatch[2]) {
+        throw new Error(`Expected ${commitSHA} in summary '${checkRun.output.summary}' of tag-git run ${checkRun.id}: ${checkRun.url}`)
+    }
+    const gitVersion = gitVersionMatch[1]
+
+    let res = ''
+
+    const architecturesToTrigger = []
+    const { listCheckRunsForCommit, queueCheckRun } = require('./check-runs')
+    for (const architecture of ['x86_64', 'i686']) {
+        const workflowName = `git-artifacts-${architecture}`
+        const runs = await listCheckRunsForCommit(
+            context,
+            await getToken(context, checkRunOwner, checkRunRepo),
+            checkRunOwner,
+            checkRunRepo,
+            commitSHA,
+            workflowName
+        )
+        const latest = runs
+            .filter(run => run.output.summary.endsWith(`(tag-git run #${workflowRunId})`))
+            .sort((a, b) => a.id - b.id)
+            .pop()
+        if (latest && (latest.status !== 'completed' || latest.conclusion === 'success')) {
+            // It either succeeded or is still running
+            res = `${res}${workflowName} run already exists at ${latest.html_url}.\n`
+        } else {
+            architecturesToTrigger.push(architecture)
+        }
+    }
+
+    if (architecturesToTrigger.length === 0) return `${res}No workflows need to be run!\n`
+
+    for (const architecture of architecturesToTrigger) {
+        const workflowName = `git-artifacts-${architecture}`
+        const title = `Build Git ${gitVersion} artifacts`
+        const summary = `Build Git ${gitVersion} artifacts from commit ${commitSHA} (tag-git run #${workflowRunId})`
+        await queueCheckRun(
+            context,
+            await getToken(context, checkRunOwner, checkRunRepo),
+            checkRunOwner,
+            checkRunRepo,
+            commitSHA,
+            workflowName,
+            title,
+            summary
+        )
+    }
+
+    const triggerWorkflowDispatch = require('./trigger-workflow-dispatch')
+    for (const architecture of architecturesToTrigger) {
+        const run = await triggerWorkflowDispatch(
+            context,
+            await getToken(context, owner, repo),
+            owner,
+            repo,
+            'git-artifacts.yml',
+            'main', {
+                architecture,
+                tag_git_workflow_run_id: workflowRunId
+            }
+        )
+        res = `${res}The \`git-artifacts-${architecture}\` workflow run [was started](${run.html_url}).\n`
+    }
+
+    return res
+}
+
+const cascadingRuns = async (context, req) => {
     const action = req.body.action
     const checkRunOwner = req.body.repository.owner.login
     const checkRunRepo = req.body.repository.name
     const checkRun = req.body.check_run
-    const commitSHA = checkRun.head_sha
     const name = checkRun.name
-    const conclusion = checkRun.conclusion
-    const text = checkRun.output.text
-
-    const getToken = (() => {
-        const tokens = {}
-
-        const get = async (owner, repo) => {
-            const getInstallationIdForRepo = require('./get-installation-id-for-repo')
-            const installationId = await getInstallationIdForRepo(context, owner, repo)
-            const getInstallationAccessToken = require('./get-installation-access-token')
-            return await getInstallationAccessToken(context, installationId)
-        }
-
-        return async (owner, repo) => tokens[[owner, repo]] || (tokens[[owner, repo]] = await get(owner, repo))
-    })()
 
     if (action === 'completed') {
         if (name === 'tag-git') {
@@ -27,91 +114,14 @@ module.exports = async (context, req) => {
                 throw new Error(`Refusing to handle cascading run in ${checkRunOwner}/${checkRunRepo}`)
             }
 
-            if (conclusion !== 'success') {
-                throw new Error(`tag-git run ${checkRun.id} completed with ${conclusion}: ${checkRun.html_url}`)
-            }
-
-            const match = text.match(/For details, see \[this run\]\(https:\/\/github.com\/([^/]+)\/([^/]+)\/actions\/runs\/(\d+)\)/)
-            if (!match) throw new Error(`Unhandled 'text' attribute of tag-git run ${checkRun.id}: ${checkRun.url}`)
-            const owner = match[1]
-            const repo = match[2]
-            const workflowRunId = Number(match[3])
-            if (owner !== 'git-for-windows' || repo !== 'git-for-windows-automation') {
-                throw new Error(`Unexpected repository ${owner}/${repo} for tag-git run ${checkRun.id}: ${checkRun.url}`)
-            }
-
-            let res = ''
-
-            const architecturesToTrigger = []
-            const { listCheckRunsForCommit, queueCheckRun } = require('./check-runs')
-            for (const architecture of ['x86_64', 'i686']) {
-                const workflowName = `git-artifacts-${architecture}`
-                const runs = await listCheckRunsForCommit(
-                    context,
-                    await getToken(checkRunOwner, checkRunRepo),
-                    checkRunOwner,
-                    checkRunRepo,
-                    commitSHA,
-                    workflowName
-                )
-                const latest = runs
-                    .filter(run => run.output.summary.endsWith(`(tag-git run #${workflowRunId})`))
-                    .sort((a, b) => a.id - b.id)
-                    .pop()
-                if (latest && (latest.status !== 'completed' || latest.conclusion === 'success')) {
-                    // It either succeeded or is still running
-                    res = `${res}${workflowName} run already exists at ${latest.html_url}.\n`
-                } else {
-                    architecturesToTrigger.push(architecture)
-                }
-            }
-
-            if (architecturesToTrigger.length === 0) return `${res}No workflows need to be run!\n`
-
-            const gitVersionMatch = checkRun.output.summary.match(/^Tag Git (\S+) @([0-9a-f]+)$/)
-            if (!gitVersionMatch) {
-                throw new Error(`Could not parse Git version from summary '${checkRun.output.summary}' of tag-git run ${checkRun.id}: ${checkRun.url}`)
-            }
-            if (commitSHA !== gitVersionMatch[2]) {
-                throw new Error(`Expected ${commitSHA} in summary '${checkRun.output.summary}' of tag-git run ${checkRun.id}: ${checkRun.url}`)
-            }
-            const gitVersion = gitVersionMatch[1]
-
-            for (const architecture of architecturesToTrigger) {
-                const workflowName = `git-artifacts-${architecture}`
-                const title = `Build Git ${gitVersion} artifacts`
-                const summary = `Build Git ${gitVersion} artifacts from commit ${commitSHA} (tag-git run #${workflowRunId})`
-                await queueCheckRun(
-                    context,
-                    await getToken(checkRunOwner, checkRunRepo),
-                    checkRunOwner,
-                    checkRunRepo,
-                    commitSHA,
-                    workflowName,
-                    title,
-                    summary
-                )
-            }
-
-            const triggerWorkflowDispatch = require('./trigger-workflow-dispatch')
-            for (const architecture of architecturesToTrigger) {
-                const run = await triggerWorkflowDispatch(
-                    context,
-                    await getToken(owner, repo),
-                    owner,
-                    repo,
-                    'git-artifacts.yml',
-                    'main', {
-                        architecture,
-                        tag_git_workflow_run_id: workflowRunId
-                    }
-                )
-                res = `${res}The \`git-artifacts-${architecture}\` workflow run [was started](${run.html_url}).\n`
-            }
-
-            return res
+            return await triggerGitArtifactsRuns(context, checkRunOwner, checkRunRepo, checkRun)
         }
         return `Not a cascading run: ${name}; Doing nothing.`
     }
     return `Unhandled action: ${action}`
+}
+
+module.exports = {
+    triggerGitArtifactsRuns,
+    cascadingRuns
 }

--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -1,0 +1,117 @@
+module.exports = async (context, req) => {
+    const action = req.body.action
+    const checkRunOwner = req.body.repository.owner.login
+    const checkRunRepo = req.body.repository.name
+    const checkRun = req.body.check_run
+    const commitSHA = checkRun.head_sha
+    const name = checkRun.name
+    const conclusion = checkRun.conclusion
+    const text = checkRun.output.text
+
+    const getToken = (() => {
+        const tokens = {}
+
+        const get = async (owner, repo) => {
+            const getInstallationIdForRepo = require('./get-installation-id-for-repo')
+            const installationId = await getInstallationIdForRepo(context, owner, repo)
+            const getInstallationAccessToken = require('./get-installation-access-token')
+            return await getInstallationAccessToken(context, installationId)
+        }
+
+        return async (owner, repo) => tokens[[owner, repo]] || (tokens[[owner, repo]] = await get(owner, repo))
+    })()
+
+    if (action === 'completed') {
+        if (name === 'tag-git') {
+            if (checkRunOwner !== 'git-for-windows' || checkRunRepo !== 'git') {
+                throw new Error(`Refusing to handle cascading run in ${checkRunOwner}/${checkRunRepo}`)
+            }
+
+            if (conclusion !== 'success') {
+                throw new Error(`tag-git run ${checkRun.id} completed with ${conclusion}: ${checkRun.html_url}`)
+            }
+
+            const match = text.match(/For details, see \[this run\]\(https:\/\/github.com\/([^/]+)\/([^/]+)\/actions\/runs\/(\d+)\)/)
+            if (!match) throw new Error(`Unhandled 'text' attribute of tag-git run ${checkRun.id}: ${checkRun.url}`)
+            const owner = match[1]
+            const repo = match[2]
+            const workflowRunId = Number(match[3])
+            if (owner !== 'git-for-windows' || repo !== 'git-for-windows-automation') {
+                throw new Error(`Unexpected repository ${owner}/${repo} for tag-git run ${checkRun.id}: ${checkRun.url}`)
+            }
+
+            let res = ''
+
+            const architecturesToTrigger = []
+            const { listCheckRunsForCommit, queueCheckRun } = require('./check-runs')
+            for (const architecture of ['x86_64', 'i686']) {
+                const workflowName = `git-artifacts-${architecture}`
+                const runs = await listCheckRunsForCommit(
+                    context,
+                    await getToken(checkRunOwner, checkRunRepo),
+                    checkRunOwner,
+                    checkRunRepo,
+                    commitSHA,
+                    workflowName
+                )
+                const latest = runs
+                    .filter(run => run.output.summary.endsWith(`(tag-git run #${workflowRunId})`))
+                    .sort((a, b) => a.id - b.id)
+                    .pop()
+                if (latest && (latest.status !== 'completed' || latest.conclusion === 'success')) {
+                    // It either succeeded or is still running
+                    res = `${res}${workflowName} run already exists at ${latest.html_url}.\n`
+                } else {
+                    architecturesToTrigger.push(architecture)
+                }
+            }
+
+            if (architecturesToTrigger.length === 0) return `${res}No workflows need to be run!\n`
+
+            const gitVersionMatch = checkRun.output.summary.match(/^Tag Git (\S+) @([0-9a-f]+)$/)
+            if (!gitVersionMatch) {
+                throw new Error(`Could not parse Git version from summary '${checkRun.output.summary}' of tag-git run ${checkRun.id}: ${checkRun.url}`)
+            }
+            if (commitSHA !== gitVersionMatch[2]) {
+                throw new Error(`Expected ${commitSHA} in summary '${checkRun.output.summary}' of tag-git run ${checkRun.id}: ${checkRun.url}`)
+            }
+            const gitVersion = gitVersionMatch[1]
+
+            for (const architecture of architecturesToTrigger) {
+                const workflowName = `git-artifacts-${architecture}`
+                const title = `Build Git ${gitVersion} artifacts`
+                const summary = `Build Git ${gitVersion} artifacts from commit ${commitSHA} (tag-git run #${workflowRunId})`
+                await queueCheckRun(
+                    context,
+                    await getToken(checkRunOwner, checkRunRepo),
+                    checkRunOwner,
+                    checkRunRepo,
+                    commitSHA,
+                    workflowName,
+                    title,
+                    summary
+                )
+            }
+
+            const triggerWorkflowDispatch = require('./trigger-workflow-dispatch')
+            for (const architecture of architecturesToTrigger) {
+                const run = await triggerWorkflowDispatch(
+                    context,
+                    await getToken(owner, repo),
+                    owner,
+                    repo,
+                    'git-artifacts.yml',
+                    'main', {
+                        architecture,
+                        tag_git_workflow_run_id: workflowRunId
+                    }
+                )
+                res = `${res}The \`git-artifacts-${architecture}\` workflow run [was started](${run.html_url}).\n`
+            }
+
+            return res
+        }
+        return `Not a cascading run: ${name}; Doing nothing.`
+    }
+    return `Unhandled action: ${action}`
+}

--- a/GitForWindowsHelper/check-runs.js
+++ b/GitForWindowsHelper/check-runs.js
@@ -71,8 +71,23 @@ const cancelWorkflowRun = async (context, token, owner, repo, workflowRunId) => 
     console.log(answer)
 }
 
+const listCheckRunsForCommit = async (context, token, owner, repo, rev, checkRunName) => {
+    const githubApiRequest = require('./github-api-request')
+
+    const answer = await githubApiRequest(
+        context,
+        token,
+        'GET',
+        `/repos/${owner}/${repo}/commits/${rev}/check-runs?per_page=100${
+            checkRunName ? `&check_name=${checkRunName}` : ''
+        }`
+    )
+    return answer.check_runs
+}
+
 module.exports = {
     queueCheckRun,
     updateCheckRun,
-    cancelWorkflowRun
+    cancelWorkflowRun,
+    listCheckRunsForCommit
 }

--- a/GitForWindowsHelper/index.js
+++ b/GitForWindowsHelper/index.js
@@ -44,6 +44,16 @@ module.exports = async function (context, req) {
         return withStatus(500, undefined, e.toString('utf-8'))
     }
 
+    try {
+        const cascadingRuns = require('./cascading-runs.js')
+        if (req.headers['x-github-event'] === 'check_run'
+            && req.body.repository.full_name === 'git-for-windows/git'
+            && req.body.action === 'completed') return ok(await cascadingRuns(context, req))
+    } catch (e) {
+        context.log(e)
+        return withStatus(500, undefined, e.toString('utf-8'))
+    }
+
     context.log("Got headers")
     context.log(req.headers)
     context.log("Got body")

--- a/GitForWindowsHelper/index.js
+++ b/GitForWindowsHelper/index.js
@@ -45,7 +45,7 @@ module.exports = async function (context, req) {
     }
 
     try {
-        const cascadingRuns = require('./cascading-runs.js')
+        const { cascadingRuns } = require('./cascading-runs.js')
         if (req.headers['x-github-event'] === 'check_run'
             && req.body.repository.full_name === 'git-for-windows/git'
             && req.body.action === 'completed') return ok(await cascadingRuns(context, req))

--- a/GitForWindowsHelper/issues.js
+++ b/GitForWindowsHelper/issues.js
@@ -52,10 +52,21 @@ const createReactionForIssueComment = async (context, token, owner, repo, commen
     return answer.id
 }
 
+const getPRCommitSHA = async (context, token, owner, repo, pullRequestNumber) => {
+    const answer = await sendGitHubAPIRequest(
+        context,
+        token,
+        'GET',
+        `/repos/${owner}/${repo}/pulls/${pullRequestNumber}`
+    )
+    return answer.head.sha
+}
+
 module.exports = {
     addIssueComment,
     getIssue,
     getIssueComment,
     appendToIssueComment,
-    createReactionForIssueComment
+    createReactionForIssueComment,
+    getPRCommitSHA
 }

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -123,13 +123,8 @@ module.exports = async (context, req) => {
             // The commit hash of the tip commit is sadly not part of the
             // "comment.created" webhook's payload. Therefore, we have to get it
             // "by hand"
-            const githubApiRequest = require('./github-api-request')
-            const { head: { sha: ref } } = await githubApiRequest(
-                console,
-                null,
-                'GET',
-                `/repos/${owner}/${repo}/pulls/${issueNumber}`
-            )
+            const { getPRCommitSHA } = require('./issues')
+            const ref = await getPRCommitSHA(console, await getToken(), owner, repo, issueNumber)
 
             await thumbsUp()
 


### PR DESCRIPTION
This is the companion to https://github.com/git-for-windows/git-for-windows-automation/pull/38 that concludes Git for Windows' release process' journey off of Azure Pipelines.

With this PR, the `/git-artifacts` command triggers a `tag-git` workflow run, upon whose mirrored Check Run's conclusion the `git-artifacts` runs are triggered. And the `/release` picks up those runs and triggers the `release-git` workflow run.

I intend to verify the correctness of this PR (and to fix whatever is necessary) with `-rc2` which is [supposed to be released today](https://tinyurl.com/gitcal).