### PR TITLE
Prepare for the architecture split between MSYS2 runtime 3.3.* vs 3.4.*

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,7 @@
       "name": "Debug Tests",
       "program": "${workspaceRoot}/node_modules/.bin/jest",
       "cwd": "${workspaceRoot}",
+      // to restrict running to a particular test case, add something like "--testNamePattern=/deploy"
       "args": ["--runInBand", "--config", "jest.config.js"],
       "windows": {
         "program": "${workspaceFolder}/node_modules/jest/bin/jest"

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -159,10 +159,17 @@ module.exports = async (context, req) => {
 
             const toTrigger = []
             if (isMSYSPackage(package_name)) {
-                toTrigger.push(
-                    { architecture: 'x86_64' },
-                    { architecture: 'i686' }
-                )
+                if (package_name !== 'msys2-runtime-3.3') {
+                    toTrigger.push(
+                        { architecture: 'x86_64' }
+                    )
+                }
+
+                if (package_name !== 'msys2-runtime') {
+                    toTrigger.push(
+                        { architecture: 'i686' }
+                    )
+                }
             } else {
                 toTrigger.push(
                     { displayArchitecture: 'i686/x86_64' }

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -411,10 +411,10 @@ testIssueComment('/deploy msys2-runtime', {
     expect(await index(context, context.req)).toBeUndefined()
     expect(context.res.body).toEqual(`I edited the comment: appended-comment-body-existing comment body
 
-The [x86_64](dispatched-workflow-build-and-deploy.yml) and the [i686](dispatched-workflow-build-and-deploy.yml) workflow runs were started.`)
-    expect(mockQueueCheckRun).toHaveBeenCalledTimes(2)
-    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(2)
-    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['i686', 'x86_64'])
+The workflow run [was started](dispatched-workflow-build-and-deploy.yml).`)
+    expect(mockQueueCheckRun).toHaveBeenCalledTimes(1)
+    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(1)
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['x86_64'])
 })
 
 testIssueComment('/deploy msys2-runtime-3.3', {
@@ -433,10 +433,10 @@ testIssueComment('/deploy msys2-runtime-3.3', {
     expect(await index(context, context.req)).toBeUndefined()
     expect(context.res.body).toEqual(`I edited the comment: appended-comment-body-existing comment body
 
-The [x86_64](dispatched-workflow-build-and-deploy.yml) and the [i686](dispatched-workflow-build-and-deploy.yml) workflow runs were started.`)
-    expect(mockQueueCheckRun).toHaveBeenCalledTimes(2)
-    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(2)
-    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['i686', 'x86_64'])
+The workflow run [was started](dispatched-workflow-build-and-deploy.yml).`)
+    expect(mockQueueCheckRun).toHaveBeenCalledTimes(1)
+    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(1)
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['i686'])
 })
 
 testIssueComment('/add release note', {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -103,6 +103,9 @@ let mockGitHubApiRequest = jest.fn((_context, _token, method, requestPath, paylo
     if (method === 'GET' && requestPath.endsWith('/pulls/86')) return {
         head: { sha: '707a11ee' }
     }
+    if (method === 'GET' && requestPath.endsWith('/pulls/500')) return {
+        head: { sha: '82e8648' }
+    }
     if (method === 'GET' && requestPath.endsWith('/pulls/4322')) return {
         head: { sha: 'c8edb521bdabec14b07e9142e48cab77a40ba339' }
     }
@@ -337,6 +340,28 @@ The [x86_64](dispatched-workflow-build-and-deploy.yml) and the [i686](dispatched
     expect(mockUpdateCheckRun).toHaveBeenCalledTimes(2)
     expect(dispatchedWorkflows).toHaveLength(2)
     expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['i686', 'x86_64'])
+})
+
+testIssueComment('/deploy mingw-w64-git-credential-manager', {
+    issue: {
+        number: 500,
+        title: 'mingw-w64-git-credential-manager: update to 2.1.2',
+        body: 'This closes https://github.com/git-for-windows/git/issues/4415',
+        pull_request: {
+            html_url: 'https://github.com/git-for-windows/build-extra/pull/500'
+        }
+    },
+    repository: {
+        name: 'build-extra'
+    }
+}, async (context) => {
+    expect(await index(context, context.req)).toBeUndefined()
+    expect(context.res.body).toEqual(`I edited the comment: appended-comment-body-existing comment body
+
+The workflow run [was started](dispatched-workflow-build-and-deploy.yml).`)
+    expect(mockQueueCheckRun).toHaveBeenCalledTimes(1)
+    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(1)
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual([undefined])
 })
 
 testIssueComment('/add release note', {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -109,6 +109,12 @@ let mockGitHubApiRequest = jest.fn((_context, _token, method, requestPath, paylo
     if (method === 'GET' && requestPath.endsWith('/pulls/74')) return {
         head: { sha: 'a7e4b90' }
     }
+    if (method === 'GET' && requestPath.endsWith('/pulls/90')) return {
+        head: { sha: '265d07e' }
+    }
+    if (method === 'GET' && requestPath.endsWith('/pulls/96')) return {
+        head: { sha: 'b7b0dfc' }
+    }
     if (method === 'GET' && requestPath.endsWith('/pulls/4322')) return {
         head: { sha: 'c8edb521bdabec14b07e9142e48cab77a40ba339' }
     }
@@ -387,6 +393,50 @@ The [i686/x86_64](dispatched-workflow-build-and-deploy.yml) and the [arm64](disp
     expect(mockQueueCheckRun).toHaveBeenCalledTimes(2)
     expect(mockUpdateCheckRun).toHaveBeenCalledTimes(2)
     expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['aarch64', undefined])
+})
+
+testIssueComment('/deploy msys2-runtime', {
+    issue: {
+        number: 90,
+        title: 'msys2-runtime: avoid sharing incompatible cygheaps, take two',
+        body: 'This is a companion to https://github.com/git-for-windows/msys2-runtime/pull/49.',
+        pull_request: {
+            html_url: 'https://github.com/git-for-windows/MSYS2-packages/pull/90'
+        }
+    },
+    repository: {
+        name: 'MSYS2-packages'
+    }
+}, async (context) => {
+    expect(await index(context, context.req)).toBeUndefined()
+    expect(context.res.body).toEqual(`I edited the comment: appended-comment-body-existing comment body
+
+The [x86_64](dispatched-workflow-build-and-deploy.yml) and the [i686](dispatched-workflow-build-and-deploy.yml) workflow runs were started.`)
+    expect(mockQueueCheckRun).toHaveBeenCalledTimes(2)
+    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(2)
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['i686', 'x86_64'])
+})
+
+testIssueComment('/deploy msys2-runtime-3.3', {
+    issue: {
+        number: 96,
+        title: 'add a msys2-runtime-3.3 package',
+        body: 'The first step of phase 2 of the current timeline(https://github.com/git-for-windows/git/issues/4279#issue-1577622335)',
+        pull_request: {
+            html_url: 'https://github.com/git-for-windows/MSYS2-packages/pull/96'
+        }
+    },
+    repository: {
+        name: 'MSYS2-packages'
+    }
+}, async (context) => {
+    expect(await index(context, context.req)).toBeUndefined()
+    expect(context.res.body).toEqual(`I edited the comment: appended-comment-body-existing comment body
+
+The [x86_64](dispatched-workflow-build-and-deploy.yml) and the [i686](dispatched-workflow-build-and-deploy.yml) workflow runs were started.`)
+    expect(mockQueueCheckRun).toHaveBeenCalledTimes(2)
+    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(2)
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['i686', 'x86_64'])
 })
 
 testIssueComment('/add release note', {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -106,6 +106,9 @@ let mockGitHubApiRequest = jest.fn((_context, _token, method, requestPath, paylo
     if (method === 'GET' && requestPath.endsWith('/pulls/500')) return {
         head: { sha: '82e8648' }
     }
+    if (method === 'GET' && requestPath.endsWith('/pulls/74')) return {
+        head: { sha: 'a7e4b90' }
+    }
     if (method === 'GET' && requestPath.endsWith('/pulls/4322')) return {
         head: { sha: 'c8edb521bdabec14b07e9142e48cab77a40ba339' }
     }
@@ -362,6 +365,28 @@ The workflow run [was started](dispatched-workflow-build-and-deploy.yml).`)
     expect(mockQueueCheckRun).toHaveBeenCalledTimes(1)
     expect(mockUpdateCheckRun).toHaveBeenCalledTimes(1)
     expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual([undefined])
+})
+
+testIssueComment('/deploy mingw-w64-curl', {
+    issue: {
+        number: 74,
+        title: 'mingw-w64-curl: update to 8.0.1',
+        body: 'This closes https://github.com/git-for-windows/git/issues/4354',
+        pull_request: {
+            html_url: 'https://github.com/git-for-windows/MINGW-packages/pull/74'
+        }
+    },
+    repository: {
+        name: 'MINGW-packages'
+    }
+}, async (context) => {
+    expect(await index(context, context.req)).toBeUndefined()
+    expect(context.res.body).toEqual(`I edited the comment: appended-comment-body-existing comment body
+
+The [i686/x86_64](dispatched-workflow-build-and-deploy.yml) and the [arm64](dispatched-workflow-build-and-deploy.yml) workflow runs were started.`)
+    expect(mockQueueCheckRun).toHaveBeenCalledTimes(2)
+    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(2)
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['aarch64', undefined])
 })
 
 testIssueComment('/add release note', {


### PR DESCRIPTION
From here on out, we will build `msys2-runtime-3.3` only for i686, and `msys2-runtime` only for x86_64. This is a necessary prerequisite for upgrading `msys2-runtime` to the current version, v3.4.6, because that simply does not support i686 anymore (and to accommodate for that, we move `git-sdk-32` to using `msys2-runtime-3.3` instead of `msys2-runtime`).