### PR TITLE
Guess better cURL release notes

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -67,6 +67,7 @@ const guessReleaseNotes = async (context, issue) => {
 
     const matchURL = async () => {
         if (package_name === 'perl') return `http://search.cpan.org/dist/perl-${version}/pod/perldelta.pod`
+        if (package_name === 'curl') return `https://curl.se/changes.html#${version.replaceAll('.', '_')}`
 
         if (!issue.pull_request) return matchURLInIssue(issue)
 

--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -11,7 +11,7 @@ const guessComponentUpdateDetails = (title, body) => {
     else if (package_name === 'cygwin') package_name = 'msys2-runtime'
 
     version = version
-        .replace(/^(GCM |openssl-|OpenSSL_|v|V_|GnuTLS |tig-|Heimdal |cygwin-|PCRE2-|Bash-)/, '')
+        .replace(/^(GCM |openssl-|OpenSSL_|v|V_|GnuTLS |tig-|Heimdal |cygwin-|PCRE2-|Bash-|curl-)/, '')
         .replace(/\s+patch\s+/, '.')
         .replace(/_/g, '.')
         .replace(/-release$/, '')

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -29,6 +29,7 @@ test('guessComponentUpdateDetails()', () => {
         ['[New openssh version] V_9_2_P1', 'openssh', '9.2.P1'],
         ['[New tig version] tig-2.5.8', 'tig', '2.5.8'],
         ['[New curl version] 7.87.0', 'curl', '7.87.0'],
+        ['[New curl version] curl-8_1_1', 'curl', '8.1.1'],
         ['[New mintty version] 3.6.3', 'mintty', '3.6.3'],
         ['[New pcre2 version] PCRE2-10.42', 'pcre2', '10.42'],
         ['[New git-lfs version] v3.3.0', 'mingw-w64-git-lfs', '3.3.0'],

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -87,4 +87,13 @@ http://www.gnutls.org/news.html#2023-02-10`
         type: 'feature',
         message: 'Comes with [Perl v5.36.1](http://search.cpan.org/dist/perl-5.36.1/pod/perldelta.pod).'
     })
+
+    expect(await guessReleaseNotes(context, {
+        labels: [{ name: 'component-update' }],
+        title: '[New curl version] curl-8_1_1',
+        body: `\nhttps://github.com/curl/curl/releases/tag/curl-8_1_1`
+    })).toEqual({
+        type: 'feature',
+        message: 'Comes with [cURL v8.1.1](https://curl.se/changes.html#8_1_1).'
+    })
 })


### PR DESCRIPTION
The `/open pr` automation failed in https://github.com/git-for-windows/git/issues/4439, not only because the `curl.haxx.se/download` links no longer work, and not only because `.tar.bz2` files are at https://github.com/curl/curl/releases now instead of `.tar.xz` files, but also because the RSS feed item format changed.

Let's fix that, and while at it, reinstate the better links to cURL's release notes that we used to provide in the good old `please.sh upgrade curl` times.