### PR TITLE
guess release notes: special-case OpenSSL

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -68,6 +68,9 @@ const guessReleaseNotes = async (context, issue) => {
     const matchURL = async () => {
         if (package_name === 'perl') return `http://search.cpan.org/dist/perl-${version}/pod/perldelta.pod`
         if (package_name === 'curl') return `https://curl.se/changes.html#${version.replaceAll('.', '_')}`
+        if (package_name === 'openssl') return `https://www.openssl.org/news/openssl-${
+            version.replace(/^(1\.1\.1|[3-9]\.\d+).*/, '$1')
+        }-notes.html`
 
         if (!issue.pull_request) return matchURLInIssue(issue)
 

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -96,4 +96,22 @@ http://www.gnutls.org/news.html#2023-02-10`
         type: 'feature',
         message: 'Comes with [cURL v8.1.1](https://curl.se/changes.html#8_1_1).'
     })
+
+    expect(await guessReleaseNotes(context, {
+        labels: [{ name: 'component-update' }],
+        title: '[New openssl version] OpenSSL 1.1.1u',
+        body: `\nhttps://github.com/openssl/openssl/releases/tag/OpenSSL_1_1_1u`
+    })).toEqual({
+        type: 'feature',
+        message: 'Comes with [OpenSSL v1.1.1u](https://www.openssl.org/news/openssl-1.1.1-notes.html).'
+    })
+
+    expect(await guessReleaseNotes(context, {
+        labels: [{ name: 'component-update' }],
+        title: '[New openssl version] OpenSSL 3.1.1',
+        body: `\nhttps://github.com/openssl/openssl/releases/tag/openssl-3.1.1`
+    })).toEqual({
+        type: 'feature',
+        message: 'Comes with [OpenSSL v3.1.1](https://www.openssl.org/news/openssl-3.1-notes.html).'
+    })
 })


### PR DESCRIPTION
We would like to show useful links in the release notes for new OpenSSL versions, just like [we did before we switched from using `please.sh upgrade openssl` to branch deployments](https://github.com/git-for-windows/build-extra/blob/d488d45e052b/please.sh#L1930-L1932).

This is a sibling to #34.