### PR TITLE
PR: test with node.js 18.x

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - uses: actions/checkout@v3
       - name: npm install
         run: npm install


### PR DESCRIPTION
As per https://github.com/nodejs/release#release-schedule node.js 16.x is only in maintenance mode. Prior to switching over this here GitHub App from node.js 16.x to 18.x, make sure that it actually works with that node.js version.