### PR TITLE
Make `/add relnote` safer to use

### DIFF
--- a/GitForWindowsHelper/azure-pipelines.js
+++ b/GitForWindowsHelper/azure-pipelines.js
@@ -10,7 +10,7 @@ const triggerAzurePipeline = async (context, token, organization, project, build
         'parameters': JSON.stringify(parameters),
     }
 
-    const httpsRequest = require('./https-request')
+    const { httpsRequest } = require('./https-request')
     return await httpsRequest(
         context,
         'dev.azure.com',
@@ -49,7 +49,7 @@ const listReleases = async (context, token, organization, project) => {
         'Authorization': 'Basic ' + auth,
     }
 
-    const httpsRequest = require('./https-request')
+    const { httpsRequest } = require('./https-request')
     return await httpsRequest(
         context,
         'vsrm.dev.azure.com',
@@ -67,7 +67,7 @@ const getRelease = async (context, token, organization, project, releaseId) => {
         'Authorization': 'Basic ' + auth,
     }
 
-    const httpsRequest = require('./https-request')
+    const { httpsRequest } = require('./https-request')
     return await httpsRequest(
         context,
         'vsrm.dev.azure.com',
@@ -120,7 +120,7 @@ const createRelease = async (
         properties: { ReleaseCreationSource: "GitForWindowsHelper" },
     }
 
-    const httpsRequest = require('./https-request')
+    const { httpsRequest } = require('./https-request')
     return await httpsRequest(
         context,
         'vsrm.dev.azure.com',

--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -42,6 +42,10 @@ const isMSYSPackage = package_name => {
         && !package_name.startsWith('mingw-w64-')
 }
 
+const packageNeedsBothMSYSAndMINGW = package_name => {
+    return ['openssl', 'curl', 'gnutls', 'pcre2'].includes(package_name)
+}
+
 const needsSeparateARM64Build = package_name => {
     if (package_name === 'git-extra') return true
     return package_name.startsWith('mingw-w64-') && ![
@@ -108,5 +112,6 @@ module.exports = {
     guessReleaseNotes,
     prettyPackageName,
     isMSYSPackage,
+    packageNeedsBothMSYSAndMINGW,
     needsSeparateARM64Build
 }

--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -93,11 +93,13 @@ const guessReleaseNotes = async (context, issue) => {
     const url = await matchURL()
     if (!url) throw new Error(`Could not determine URL from issue ${issue.number}`)
 
-    package_name = prettyPackageName(package_name.replace(/^mingw-w64-/, ''))
+    const prettyName = prettyPackageName(package_name.replace(/^mingw-w64-/, ''))
 
     return {
         type: 'feature',
-        message: `Comes with [${package_name} v${version}](${url}).`
+        message: `Comes with [${prettyName} v${version}](${url}).`,
+        package: package_name,
+        version
     }
 }
 

--- a/GitForWindowsHelper/github-api-request-as-app.js
+++ b/GitForWindowsHelper/github-api-request-as-app.js
@@ -29,7 +29,7 @@ module.exports = async (context, requestMethod, requestPath, body) => {
 
     const token = `${headerAndPayload}.${signature}`
 
-    const httpsRequest = require('./https-request')
+    const { httpsRequest } = require('./https-request')
     return await httpsRequest(
         context,
         null,

--- a/GitForWindowsHelper/github-api-request.js
+++ b/GitForWindowsHelper/github-api-request.js
@@ -1,5 +1,5 @@
 module.exports = async (context, token, method, requestPath, payload) => {
-    const httpsRequest = require('./https-request')
+    const { httpsRequest } = require('./https-request')
     const headers = token ? { Authorization: `Bearer ${token}` } : null
     const answer = await httpsRequest(context, null, method, requestPath, payload, headers)
     if (answer.error) throw answer.error

--- a/GitForWindowsHelper/https-request.js
+++ b/GitForWindowsHelper/https-request.js
@@ -1,6 +1,6 @@
 const gently = require('./gently')
 
-module.exports = async (context, hostname, method, requestPath, body, headers) => {
+const httpsRequest = async (context, hostname, method, requestPath, body, headers) => {
     headers = {
         'User-Agent': 'GitForWindowsHelper/0.0',
         Accept: 'application/json',
@@ -59,4 +59,8 @@ module.exports = async (context, hostname, method, requestPath, body, headers) =
             reject(e)
         }
     })
+}
+
+module.exports = {
+    httpsRequest
 }

--- a/GitForWindowsHelper/https-request.js
+++ b/GitForWindowsHelper/https-request.js
@@ -61,6 +61,28 @@ const httpsRequest = async (context, hostname, method, requestPath, body, header
     })
 }
 
+const doesURLReturn404 = async url => {
+    const match = url.match(/^https:\/\/([^/]+?)(:\d+)?(\/.*)?$/)
+    if (!match) throw new Error(`Could not parse URL ${url}`)
+
+    const https = require('https')
+    const options = {
+        method: 'HEAD',
+        host: match[1],
+        port: Number.parseInt(match[2] || '443'),
+        path: match[3] || '/'
+    }
+    return new Promise((resolve, reject) => {
+        https.request(options, res => {
+            if (res.error) reject(res.error)
+            else if (res.statusCode === 404) resolve(true)
+            else if (res.statusCode === 200) resolve(false)
+            else reject(`Unexpected statusCode: ${res.statusCode}`)
+        }).end()
+    })
+}
+
 module.exports = {
-    httpsRequest
+    httpsRequest,
+    doesURLReturn404
 }

--- a/GitForWindowsHelper/search.js
+++ b/GitForWindowsHelper/search.js
@@ -3,7 +3,7 @@
  * https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
  */
 const searchIssues = async (context, searchTerms) => {
-    const httpsRequest = require('./https-request');
+    const { httpsRequest } = require('./https-request');
     const answer = await httpsRequest(
         context,
         'api.github.com',

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -462,10 +462,18 @@ module.exports = async (context, req) => {
 
             await checkPermissions()
 
+            const { appendToIssueComment } = require('./issues')
             let [ , , , type, message ] = relNotesMatch
             if (!type) {
-                const { guessReleaseNotes } = require('./component-updates');
-                ({ type, message } = await guessReleaseNotes(context, req.body.issue))
+                const { guessReleaseNotes, getMissingDeployments } = require('./component-updates');
+                let package_name, version
+                ({ type, message, package: package_name, version } = await guessReleaseNotes(context, req.body.issue))
+                const missingDeployments = await getMissingDeployments(package_name, version)
+                if (missingDeployments.length > 0) {
+                    const message = `The following deployment(s) are missing:\n\n* ${missingDeployments.join('\n* ')}`
+                    await appendToIssueComment(context, await getToken(), owner, repo, commentId, message)
+                    throw new Error(message)
+                }
             }
 
             await thumbsUp()
@@ -482,7 +490,6 @@ module.exports = async (context, req) => {
                     message
                 }
             )
-            const { appendToIssueComment } = require('./issues')
             const answer2 = await appendToIssueComment(context, await getToken(), owner, repo, commentId, `The workflow run [was started](${answer.html_url})`)
             return `I edited the comment: ${answer2.html_url}`
         }

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -54,7 +54,7 @@ module.exports = async (context, req) => {
 
             await checkPermissions()
 
-            const { guessComponentUpdateDetails } = require('./component-updates')
+            const { guessComponentUpdateDetails, packageNeedsBothMSYSAndMINGW } = require('./component-updates')
             const { package_name, version } = guessComponentUpdateDetails(req.body.issue.title, req.body.issue.body)
 
             await thumbsUp()
@@ -96,7 +96,7 @@ module.exports = async (context, req) => {
                 );
                 ({ html_url: commentURL, id: commentId } = await appendToIssueComment(context, await getToken(), owner, repo, commentId, `The${packageType ? ` ${packageType}` : ''} workflow run [was started](${answer.html_url})`))
             }
-            if (!['openssl', 'curl', 'gnutls', 'pcre2'].includes(package_name)) {
+            if (!packageNeedsBothMSYSAndMINGW(package_name)) {
                 await openPR(package_name)
             } else {
                 await openPR(package_name, 'MSYS')

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -63,7 +63,9 @@ test('guessReleaseNotes()', async () => {
         body: bashTicketBody
     })).toEqual({
         type: 'feature',
-        message: 'Comes with [Bash v5.2.15](https://git.savannah.gnu.org/cgit/bash.git/commit/?id=ec8113b9861375e4e17b3307372569d429dec814).'
+        message: 'Comes with [Bash v5.2.15](https://git.savannah.gnu.org/cgit/bash.git/commit/?id=ec8113b9861375e4e17b3307372569d429dec814).',
+        package: 'bash',
+        version: '5.2.15'
     })
 
     expect(await guessReleaseNotes(context, {
@@ -76,7 +78,9 @@ Added the security advisory.[GNUTLS-SA-2020-07-14](security-new.html#GNUTLS-SA-2
 http://www.gnutls.org/news.html#2023-02-10`
     })).toEqual({
         type: 'feature',
-        message: 'Comes with [GNU TLS v3.8.0](https://lists.gnupg.org/pipermail/gnutls-help/2023-February/004816.html).'
+        message: 'Comes with [GNU TLS v3.8.0](https://lists.gnupg.org/pipermail/gnutls-help/2023-February/004816.html).',
+        package: 'gnutls',
+        version: '3.8.0'
     })
 
     expect(await guessReleaseNotes(context, {
@@ -85,7 +89,9 @@ http://www.gnutls.org/news.html#2023-02-10`
         body: `\nhttps://github.com/Perl/perl5/releases/tag/v5.36.1`
     })).toEqual({
         type: 'feature',
-        message: 'Comes with [Perl v5.36.1](http://search.cpan.org/dist/perl-5.36.1/pod/perldelta.pod).'
+        message: 'Comes with [Perl v5.36.1](http://search.cpan.org/dist/perl-5.36.1/pod/perldelta.pod).',
+        package: 'perl',
+        version: '5.36.1'
     })
 
     expect(await guessReleaseNotes(context, {
@@ -94,7 +100,9 @@ http://www.gnutls.org/news.html#2023-02-10`
         body: `\nhttps://github.com/curl/curl/releases/tag/curl-8_1_1`
     })).toEqual({
         type: 'feature',
-        message: 'Comes with [cURL v8.1.1](https://curl.se/changes.html#8_1_1).'
+        message: 'Comes with [cURL v8.1.1](https://curl.se/changes.html#8_1_1).',
+        package: 'curl',
+        version: '8.1.1'
     })
 
     expect(await guessReleaseNotes(context, {
@@ -103,7 +111,9 @@ http://www.gnutls.org/news.html#2023-02-10`
         body: `\nhttps://github.com/openssl/openssl/releases/tag/OpenSSL_1_1_1u`
     })).toEqual({
         type: 'feature',
-        message: 'Comes with [OpenSSL v1.1.1u](https://www.openssl.org/news/openssl-1.1.1-notes.html).'
+        message: 'Comes with [OpenSSL v1.1.1u](https://www.openssl.org/news/openssl-1.1.1-notes.html).',
+        package: 'openssl',
+        version: '1.1.1u'
     })
 
     expect(await guessReleaseNotes(context, {
@@ -112,6 +122,8 @@ http://www.gnutls.org/news.html#2023-02-10`
         body: `\nhttps://github.com/openssl/openssl/releases/tag/openssl-3.1.1`
     })).toEqual({
         type: 'feature',
-        message: 'Comes with [OpenSSL v3.1.1](https://www.openssl.org/news/openssl-3.1-notes.html).'
+        message: 'Comes with [OpenSSL v3.1.1](https://www.openssl.org/news/openssl-3.1-notes.html).',
+        package: 'openssl',
+        version: '3.1.1'
     })
 })

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -1,6 +1,7 @@
 const {
     guessComponentUpdateDetails,
-    guessReleaseNotes
+    guessReleaseNotes,
+    getMissingDeployments
 } = require('../GitForWindowsHelper/component-updates')
 
 const bashTicketBody = `# [New bash version] Bash-5.2 patch 15: fix too-aggressive optimizing forks out of subshell commands
@@ -126,4 +127,14 @@ http://www.gnutls.org/news.html#2023-02-10`
         package: 'openssl',
         version: '3.1.1'
     })
+})
+
+test('getMissingDeployments()', async () => {
+    const missingURL = 'https://wingit.blob.core.windows.net/x86-64/curl-8.1.2-1-x86_64.pkg.tar.xz'
+    const mockDoesURLReturn404 = jest.fn(url => url === missingURL)
+    jest.mock('../GitForWindowsHelper/https-request', () => {
+        return { doesURLReturn404: mockDoesURLReturn404 }
+    })
+
+    expect(await getMissingDeployments('curl', '8.1.2')).toEqual([missingURL])
 })


### PR DESCRIPTION
It is all too easy to run `/add release note` in a `component-update` ticket, and easy to miss that the package files have not been deployed (or that a deployment failed). This happened e.g. [here](https://github.com/git-for-windows/git/issues/4523).

This PR adds automation to help prevent such issues in the future, by verifying whether the corresponding package files have been deployed (and complaining loudly if any deployed files are missing).