### PR TITLE
/add relnote: respect MinTTY's "epoch"

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -120,6 +120,9 @@ const pacmanRepositoryURLs = (package_name, version) =>
         ]
 
 const getMissingDeployments = async (package_name, version) => {
+    // MinTTY is at epoch 1, which is part of Pacman's versioning scheme
+    if (package_name === 'mintty') version = `1~${version}`
+
     const urls = []
     const msysName = package_name.replace(/^mingw-w64-/, '')
     if (packageNeedsBothMSYSAndMINGW(msysName)) {

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -131,10 +131,12 @@ http://www.gnutls.org/news.html#2023-02-10`
 
 test('getMissingDeployments()', async () => {
     const missingURL = 'https://wingit.blob.core.windows.net/x86-64/curl-8.1.2-1-x86_64.pkg.tar.xz'
-    const mockDoesURLReturn404 = jest.fn(url => url === missingURL)
+    const missingMinTTYURL = 'https://wingit.blob.core.windows.net/i686/mintty-1~3.6.5-1-i686.pkg.tar.xz'
+    const mockDoesURLReturn404 = jest.fn(url => url === missingURL || url === missingMinTTYURL)
     jest.mock('../GitForWindowsHelper/https-request', () => {
         return { doesURLReturn404: mockDoesURLReturn404 }
     })
 
     expect(await getMissingDeployments('curl', '8.1.2')).toEqual([missingURL])
+    expect(await getMissingDeployments('mintty', '3.6.5')).toEqual([missingMinTTYURL])
 })


### PR DESCRIPTION
In the Pacman universe, there is the concept of an "epoch", which is part of the versioning scheme and which has more weight than the `pkgver` value.

This concept allows following projects which "re-set" their version, for example (e.g. switching from a date-based "version" to an actual version that would naturally sort way below the previous date-based one).

In the Git for Windows project, we incremented the epoch of the `mintty` package, originally simply to override MSYS2's `mintty`, even if that was technically not even necessary.

Yet it is part of Git for Windows' legacy that the `/add release note` command needs to keep in mind when trying to verify that the `mintty` packages have been deployed properly.

Thankfully, `mintty` is the only package built by Git for Windows that has an epoch set, and hence it is the only package that needs to be treated specially in this way.