### PR TITLE
Adjust `msys2-runtime` deployment expectations

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -121,6 +121,8 @@ const getMissingDeployments = async (package_name, version) => {
     // MinTTY is at epoch 1, which is part of Pacman's versioning scheme
     if (package_name === 'mintty') version = `1~${version}`
     const architectures = ['i686', 'x86_64']
+    if (package_name === 'msys2-runtime') architectures.shift()
+    else if (package_name === 'msys2-runtime-3.3') architectures.pop()
 
     const urls = []
     const msysName = package_name.replace(/^mingw-w64-/, '')

--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -109,27 +109,26 @@ const guessReleaseNotes = async (context, issue) => {
 
 const pacmanRepositoryBaseURL = 'https://wingit.blob.core.windows.net/'
 
-const pacmanRepositoryURLs = (package_name, version) =>
-    isMSYSPackage(package_name)
-        ? [
-            `${pacmanRepositoryBaseURL}i686/${package_name}-${version}-1-i686.pkg.tar.xz`,
-            `${pacmanRepositoryBaseURL}x86-64/${package_name}-${version}-1-x86_64.pkg.tar.xz`
-        ] : [
-            `${pacmanRepositoryBaseURL}i686/${package_name.replace(/^mingw-w64/, '$&-i686')}-${version}-1-any.pkg.tar.xz`,
-            `${pacmanRepositoryBaseURL}x86-64/${package_name.replace(/^mingw-w64/, '$&-x86_64')}-${version}-1-any.pkg.tar.xz`
-        ]
+const pacmanRepositoryURLs = (package_name, version, architectures) =>
+    architectures.map(arch => {
+        const fileName = isMSYSPackage(package_name)
+            ? `${package_name}-${version}-1-${arch}.pkg.tar.xz`
+            : `${package_name.replace(/^mingw-w64/, `$&-${arch}`)}-${version}-1-any.pkg.tar.xz`
+        return `${pacmanRepositoryBaseURL}${arch.replace(/_/g, '-')}/${fileName}`
+    })
 
 const getMissingDeployments = async (package_name, version) => {
     // MinTTY is at epoch 1, which is part of Pacman's versioning scheme
     if (package_name === 'mintty') version = `1~${version}`
+    const architectures = ['i686', 'x86_64']
 
     const urls = []
     const msysName = package_name.replace(/^mingw-w64-/, '')
     if (packageNeedsBothMSYSAndMINGW(msysName)) {
-        urls.push(...pacmanRepositoryURLs(msysName, version))
-        urls.push(...pacmanRepositoryURLs(`mingw-w64-${msysName}`, version))
+        urls.push(...pacmanRepositoryURLs(msysName, version, architectures))
+        urls.push(...pacmanRepositoryURLs(`mingw-w64-${msysName}`, version, architectures))
     } else {
-        urls.push(...pacmanRepositoryURLs(package_name, version))
+        urls.push(...pacmanRepositoryURLs(package_name, version, architectures))
     }
     const { doesURLReturn404 } = require('./https-request')
     const result = await Promise.all(urls.map(async url => doesURLReturn404(url)))

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -132,11 +132,17 @@ http://www.gnutls.org/news.html#2023-02-10`
 test('getMissingDeployments()', async () => {
     const missingURL = 'https://wingit.blob.core.windows.net/x86-64/curl-8.1.2-1-x86_64.pkg.tar.xz'
     const missingMinTTYURL = 'https://wingit.blob.core.windows.net/i686/mintty-1~3.6.5-1-i686.pkg.tar.xz'
-    const mockDoesURLReturn404 = jest.fn(url => url === missingURL || url === missingMinTTYURL)
+    const bogus32BitMSYS2RuntimeURL = 'https://wingit.blob.core.windows.net/i686/msys2-runtime-3.4.9-1-i686.pkg.tar.xz'
+    const bogus64BitMSYS2RuntimeURL = 'https://wingit.blob.core.windows.net/x86-64/msys2-runtime-3.3-3.3.7-1-x86_64.pkg.tar.xz'
+    const mockDoesURLReturn404 = jest.fn(url => [
+        missingURL, missingMinTTYURL, bogus32BitMSYS2RuntimeURL, bogus64BitMSYS2RuntimeURL
+    ].includes(url))
     jest.mock('../GitForWindowsHelper/https-request', () => {
         return { doesURLReturn404: mockDoesURLReturn404 }
     })
 
     expect(await getMissingDeployments('curl', '8.1.2')).toEqual([missingURL])
     expect(await getMissingDeployments('mintty', '3.6.5')).toEqual([missingMinTTYURL])
+    expect(await getMissingDeployments('msys2-runtime', '3.4.9')).toEqual([])
+    expect(await getMissingDeployments('msys2-runtime-3.3', '3.3.7')).toEqual([])
 })


### PR DESCRIPTION
Over in https://github.com/git-for-windows/git/issues/4593#issuecomment-1710125267, I tried to add a release note, which got refused because the i686 variant of the MSYS2 runtime was not deployed. This is actually correct, but GitForWindowsHelper's expectations about that are incorrect, so let's adjust the latter.