### PR TITLE
missing-deployments: learn to handle OpenSSH's version number

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -147,6 +147,9 @@ const pacmanRepositoryURLs = (package_name, version, architectures) =>
 const getMissingDeployments = async (package_name, version) => {
     // MinTTY is at epoch 1, which is part of Pacman's versioning scheme
     if (package_name === 'mintty') version = `1~${version}`
+    // The `openssh` version looks like this: 9.1p1. But the website calls it 9.1_P1
+    if (package_name === 'openssh') version = version.replace(/[_.]P/, 'p')
+
     const architectures = ['i686', 'x86_64']
     if (package_name === 'msys2-runtime') architectures.shift()
     else if (package_name === 'msys2-runtime-3.3') architectures.pop()

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -85,8 +85,9 @@ const missingURL = 'https://wingit.blob.core.windows.net/x86-64/curl-8.1.2-1-x86
 const missingMinTTYURL = 'https://wingit.blob.core.windows.net/i686/mintty-1~3.6.5-1-i686.pkg.tar.xz'
 const bogus32BitMSYS2RuntimeURL = 'https://wingit.blob.core.windows.net/i686/msys2-runtime-3.4.9-1-i686.pkg.tar.xz'
 const bogus64BitMSYS2RuntimeURL = 'https://wingit.blob.core.windows.net/x86-64/msys2-runtime-3.3-3.3.7-1-x86_64.pkg.tar.xz'
+const missingOpenSSHURL = 'https://wingit.blob.core.windows.net/i686/openssh-9.5p1-1-i686.pkg.tar.xz'
 const mockDoesURLReturn404 = jest.fn(url => [
-    missingURL, missingMinTTYURL, bogus32BitMSYS2RuntimeURL, bogus64BitMSYS2RuntimeURL
+    missingURL, missingMinTTYURL, bogus32BitMSYS2RuntimeURL, bogus64BitMSYS2RuntimeURL, missingOpenSSHURL
 ].includes(url))
 jest.mock('../GitForWindowsHelper/https-request', () => {
     return {
@@ -196,4 +197,5 @@ test('getMissingDeployments()', async () => {
     expect(await getMissingDeployments('mintty', '3.6.5')).toEqual([missingMinTTYURL])
     expect(await getMissingDeployments('msys2-runtime', '3.4.9')).toEqual([])
     expect(await getMissingDeployments('msys2-runtime-3.3', '3.3.7')).toEqual([])
+    expect(await getMissingDeployments('openssh', '9.5.P1')).toEqual([missingOpenSSHURL])
 })


### PR DESCRIPTION
OpenSSH likes to use a very funny version number format on their website, a format that we cannot use in Pacman packages, and therefore it needs to be transmogrified just like we did in
https://github.com/git-for-windows/git-for-windows-automation/pull/27 when checking for missing deployments.