### PR TITLE
Update the `/git-artifacts` PR comment even in cascading runs

### DIFF
--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -114,7 +114,17 @@ const cascadingRuns = async (context, req) => {
                 throw new Error(`Refusing to handle cascading run in ${checkRunOwner}/${checkRunRepo}`)
             }
 
-            return await triggerGitArtifactsRuns(context, checkRunOwner, checkRunRepo, checkRun)
+            const comment = await triggerGitArtifactsRuns(context, checkRunOwner, checkRunRepo, checkRun)
+
+            const token = await getToken(context, checkRunOwner, checkRunRepo)
+            const { getGitArtifactsCommentID, appendToIssueComment } = require('./issues')
+            const gitArtifactsCommentID = await getGitArtifactsCommentID(context, token, checkRunOwner, checkRunRepo, req.body.check_run.head_sha)
+
+            if (gitArtifactsCommentID) {
+                await appendToIssueComment(context, token, checkRunOwner, checkRunRepo, gitArtifactsCommentID, comment)
+            }
+
+            return comment
         }
         return `Not a cascading run: ${name}; Doing nothing.`
     }

--- a/GitForWindowsHelper/github-api-request.js
+++ b/GitForWindowsHelper/github-api-request.js
@@ -1,6 +1,8 @@
-module.exports = async (context, token, method, requestPath, payload) => {
+module.exports = async (context, token, method, requestPath, payload, extraHeaders) => {
     const { httpsRequest } = require('./https-request')
-    const headers = token ? { Authorization: `Bearer ${token}` } : null
+    const headers = token
+        ? { ...(extraHeaders || {}), Authorization: `Bearer ${token}` }
+        : extraHeaders
     const answer = await httpsRequest(context, null, method, requestPath, payload, headers)
     if (answer.error) throw answer.error
     return answer

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -127,6 +127,27 @@ let mockGitHubApiRequest = jest.fn((_context, _token, method, requestPath, paylo
     if (method === 'GET' && requestPath.endsWith('/pulls/4323')) return {
         head: { sha: 'dee501d15' }
     }
+    if (method === 'GET' && requestPath === '/search/issues?q=repo:git-for-windows/git+c8edb521bdabec14b07e9142e48cab77a40ba339+type:pr+%22git-artifacts%22') return {
+        items: [{
+            text_matches: [{
+                object_url: 'https://api.github.com/repositories/23216272/issues/comments/1450703020',
+                fragment: '/git-artifacts\n\nThe tag-git workflow run was started\n'
+            }]
+        }]
+    }
+    if (method === 'GET' && requestPath === '/repos/git-for-windows/git/issues/comments/1450703020') return {
+        body: '/git-artifacts\n\nThe tag-git workflow run [was started](https://url-to-tag-git/)'
+    }
+    if (method === 'PATCH' && requestPath === '/repos/git-for-windows/git/issues/comments/1450703020') {
+        expect(payload.body).toEqual(`/git-artifacts
+
+The tag-git workflow run [was started](https://url-to-tag-git/)
+
+git-artifacts-x86_64 run already exists at <url-to-existing-x86_64-run>.
+The \`git-artifacts-i686\` workflow run [was started](dispatched-workflow-git-artifacts.yml).
+`)
+        return { html_url: 'https://github.com/git-for-windows/git/pull/4322#issuecomment-1450703020' }
+    }
     throw new Error(`Unhandled ${method}-${requestPath}-${JSON.stringify(payload)}`)
 })
 jest.mock('../GitForWindowsHelper/github-api-request', () => {


### PR DESCRIPTION
When a `/git-artifacts` is issued with an existing corresponding `tag-git` run, the respective comment is updated immediately with links to the `git-artifacts-*` runs.

However, when that `tag-git` run does not exist, the comment is updated with a link to the newly-triggered `tag-git` run, and when that run's completion triggers the "cascading" `git-artifacts-*` runs, the PR comment is no longer updated.

This is unfortunate because that information is rather valuable and saves time e.g. when trying to manually validate the generated installer.

So let's try a little harder to find that comment, and update it.

This fixes https://github.com/git-for-windows/gfw-helper-github-app/issues/38.