### PR TITLE
missing-deployments: learn about the Bash package's version scheme

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -149,6 +149,8 @@ const getMissingDeployments = async (package_name, version) => {
     if (package_name === 'mintty') version = `1~${version}`
     // The `openssh` version looks like this: 9.1p1. But the website calls it 9.1_P1
     if (package_name === 'openssh') version = version.replace(/[_.]P/, 'p')
+    // The `bash` version has its patch-level zero-padded to three digits
+    if (package_name === 'bash') version = version.replace(/\d+$/, n => n.padStart(3, '0'))
 
     const architectures = ['i686', 'x86_64']
     if (package_name === 'msys2-runtime') architectures.shift()

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -86,8 +86,9 @@ const missingMinTTYURL = 'https://wingit.blob.core.windows.net/i686/mintty-1~3.6
 const bogus32BitMSYS2RuntimeURL = 'https://wingit.blob.core.windows.net/i686/msys2-runtime-3.4.9-1-i686.pkg.tar.xz'
 const bogus64BitMSYS2RuntimeURL = 'https://wingit.blob.core.windows.net/x86-64/msys2-runtime-3.3-3.3.7-1-x86_64.pkg.tar.xz'
 const missingOpenSSHURL = 'https://wingit.blob.core.windows.net/i686/openssh-9.5p1-1-i686.pkg.tar.xz'
+const missingBashURL = 'https://wingit.blob.core.windows.net/x86-64/bash-5.2.020-1-x86_64.pkg.tar.xz'
 const mockDoesURLReturn404 = jest.fn(url => [
-    missingURL, missingMinTTYURL, bogus32BitMSYS2RuntimeURL, bogus64BitMSYS2RuntimeURL, missingOpenSSHURL
+    missingURL, missingMinTTYURL, bogus32BitMSYS2RuntimeURL, bogus64BitMSYS2RuntimeURL, missingOpenSSHURL, missingBashURL
 ].includes(url))
 jest.mock('../GitForWindowsHelper/https-request', () => {
     return {
@@ -198,4 +199,5 @@ test('getMissingDeployments()', async () => {
     expect(await getMissingDeployments('msys2-runtime', '3.4.9')).toEqual([])
     expect(await getMissingDeployments('msys2-runtime-3.3', '3.3.7')).toEqual([])
     expect(await getMissingDeployments('openssh', '9.5.P1')).toEqual([missingOpenSSHURL])
+    expect(await getMissingDeployments('bash', '5.2.20')).toEqual([missingBashURL])
 })


### PR DESCRIPTION
[This](https://github.com/git-for-windows/MSYS2-packages/pull/132#issuecomment-1806927187) just happened:

> /add relnote
>
> The following deployment(s) are missing:
>
> https://wingit.blob.core.windows.net/i686/bash-5.2.21-1-i686.pkg.tar.xz
> https://wingit.blob.core.windows.net/x86-64/bash-5.2.21-1-x86_64.pkg.tar.xz
> 😦 

The reason is that the patch-level of the Bash package [is 0-padded to 3 digits](https://github.com/git-for-windows/MSYS2-packages/blob/8612db42be8ed99301f867991daa093f37f121ba/bash/PKGBUILD#L7) (see also [here](https://github.com/git-for-windows/git-for-windows-automation/blob/10edc10b4cffc77ab7ada4c0466de6224debc2dc/update-scripts/version/bash#L21)).

Let's fix this in the GitForWindowsHelper, too.