### PR TITLE
Update `tag-git` comment in cascading runs; Follow up

### DIFF
--- a/GitForWindowsHelper/github-api-request-as-app.js
+++ b/GitForWindowsHelper/github-api-request-as-app.js
@@ -9,8 +9,8 @@ module.exports = async (context, requestMethod, requestPath, body) => {
     const payload = {
         // issued at time, 60 seconds in the past to allow for clock drift
         iat: now - 60,
-        // JWT expiration time (10 minute maximum)
-        exp: now + (10 * 60),
+        // JWT expiration time (10 minute maximum, use 9 to allow for clock drift)
+        exp: now + (9 * 60),
         // GitHub App's identifier
         iss: process.env['GITHUB_APP_ID']
     }

--- a/GitForWindowsHelper/issues.js
+++ b/GitForWindowsHelper/issues.js
@@ -29,7 +29,7 @@ const getGitArtifactsCommentID = async (context, token, owner, repo, headSHA) =>
     })
     const items = answer.items.filter(item =>
         item.text_matches.length === 1
-        && item.text_matches[0].fragment === '/git-artifacts\n\nThe tag-git workflow run was started\n'
+        && item.text_matches[0].fragment.trim() === '/git-artifacts\n\nThe tag-git workflow run was started'
     )
     return items.length === 1 && items[0].text_matches[0].object_url.replace(/^.*\/(\d+)$/, '$1')
 }


### PR DESCRIPTION
In #47 I tried to teach GitForWindowsHelper to find the PR comment containing `/git-artifacts` when the `tag-git` check run finished that was triggered by that slash command. However, it did not work, despite the webhook being delivered with status 200 and the response body being:

> The `git-artifacts-x86_64` workflow run [was started](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/6869163398).
> The `git-artifacts-i686` workflow run [was started](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/6869164014).

I do not really know why it failed, but when I tried to run the code locally (commenting out the part that would have triggered another pair of `git-artifacts` runs), it didn't work for me either, due to expire time issues ("too far in the future") and due to too-strict matching (sometimes the fragment in the search result ended in a newline character, sometimes it did not).

This PR is designed to help with both issues, so that hopefully the v2.43.0 (final) PR will see the `/git-artifacts` comment being updated as intended.

At least when I ran the code locally with these modifications, the [`/git-artifacts` comment was updated as I wanted](https://github.com/git-for-windows/git/pull/4692#issuecomment-1811203476), if somewhat belatedly.