### PR TITLE
/add relnote: extend `gnutls` special-casing to the MINGW variant

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -91,7 +91,7 @@ const guessReleaseNotes = async (context, issue) => {
         const pattern = {
             bash: /(?:^|\n)(https:\/\/\S+)/, // use the first URL
             gnutls: /(https:\/\/[^\s)]+)/
-        }[package_name.toLowerCase()] || /(?:^|\n)(https:\/\/\S+)$/
+        }[package_name.toLowerCase().replace(/^mingw-w64-/, '')] || /(?:^|\n)(https:\/\/\S+)$/
         const match = issue.body.match(pattern)
         return match && match[1]
     }


### PR DESCRIPTION
I already added special-casing for GNU TLS in 2085119 (guess release notes: support GNU TLS tickets better, 2023-02-15), but I forgot that it's also possible to call `/add relnote` from the `mingw-w64-gnutls` Pull Request... Let's remedy that.

This fixes https://github.com/git-for-windows/gfw-helper-github-app/issues/51