### PR TITLE
Add the `/updpkgsums` slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ For convenience, the command can be abbreviated as `/add relnote <type> <message
 
 **What does it do?** Meant to handle tickets labeled as `component-update` (typically created by [the `Monitor component updates` GitHub workflow](https://github.com/git-for-windows/git/actions/workflows/monitor-components.yml)) that notify the Git for Windows project when new versions are available of software that is shipped with Git for Windows, this command starts a [GitHub workflow run to open the corresponding Pull Request](https://github.com/git-for-windows/git-for-windows-automation/actions/workflows/open-pr.yml).
 
+### `/updpkgsums`
+
+**Where can it be called?** In Pull Requests of Git for Windows' [`build-extra`](https://github.com/git-for-windows/build-extra), [`MINGW-packages`](https://github.com/git-for-windows/MINGW-packages) and [`MSYS2-packages`](https://github.com/git-for-windows/MSYS2-packages) repositories.
+
+**What does it do?** Meant to update the checksums in `PKGBUILD` files that need to be modified to pass the integrity checks of `makepkg`.
+
 ### `/deploy [<package>]`
 
 **Where can it be called?** In Pull Requests of Git for Windows' [`build-extra`](https://github.com/git-for-windows/build-extra), [`MINGW-packages`](https://github.com/git-for-windows/MINGW-packages) and [`MSYS2-packages`](https://github.com/git-for-windows/MSYS2-packages) repositories.

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -307,6 +307,41 @@ The MINGW workflow run [was started](dispatched-workflow-open-pr.yml)`
     })
 })
 
+testIssueComment('/updpkgsums', {
+    issue: {
+        number: 104,
+        title: 'Make tig launchable from PowerShell/Command Prompt',
+        body: 'Add tig.exe to /cmd/',
+        pull_request: {
+            html_url: 'https://github.com/git-for-windows/MINGW-packages/pull/104'
+        }
+    },
+    repository: {
+        name: 'MINGW-packages'
+    }
+}, async (context) => {
+    expect(await index(context, context.req)).toBeUndefined()
+    expect(context.res).toEqual({
+        body: `I edited the comment: appended-comment-body-existing comment body
+
+The workflow run [was started](dispatched-workflow-updpkgsums.yml).`,
+        headers: undefined,
+        status: undefined
+    })
+    expect(mockGetInstallationAccessToken).toHaveBeenCalledTimes(1)
+    expect(mockGitHubApiRequestAsApp).not.toHaveBeenCalled()
+    expect(dispatchedWorkflows).toHaveLength(1)
+    expect(dispatchedWorkflows.map(e => e.payload.inputs['pr-number'])).toEqual([104])
+    expect(mockGitHubApiRequest).toHaveBeenCalled()
+    const comment = mockGitHubApiRequest.mock.calls[mockGitHubApiRequest.mock.calls.length - 1]
+    expect(comment[3]).toEqual('/repos/git-for-windows/MINGW-packages/issues/comments/0')
+    expect(comment[4]).toEqual({
+        body: `existing comment body
+
+The workflow run [was started](dispatched-workflow-updpkgsums.yml).`
+    })
+})
+
 let mockQueueCheckRun = jest.fn(() => 'check-run-id')
 let mockUpdateCheckRun = jest.fn()
 let mockListCheckRunsForCommit = jest.fn((_context, _token, _owner, _repo, rev, checkRunName) => {


### PR DESCRIPTION
Marked as draft because it needs https://github.com/git-for-windows/git-for-windows-automation/pull/62 to be merged first.

As with most of the other slash commands, this triggers a GitHub workflow run in `git-for-windows-automation`, in this instance, unsurprisingly the `upkpkgsums.yml` one.

The idea is to help contributors with their Pull Requests that fail CI builds solely due to mismatched checksums after modifying, adding or removing files from a package.

This fixes #28.