### PR TITLE
get-webhook-event-payload: show the entire event

### DIFF
--- a/get-webhook-event-payload.js
+++ b/get-webhook-event-payload.js
@@ -107,6 +107,6 @@
     const events = await getMatchingEvents()
     for (const e of events) {
         const fullEvent = await gitHubRequestAsApp(console, 'GET', `/app/hook/deliveries/${e.id}`)
-        console.log(`id: ${e.id}\naction: ${e.action}\nrequest: ${JSON.stringify(fullEvent.request, null, 2)}`)
+        console.log(`id: ${e.id}\naction: ${e.action}\nevent: ${JSON.stringify(fullEvent, null, 2)}`)
     }
 })().catch(console.log)


### PR DESCRIPTION
Previously, I only showed the request. But that's not all of the good information that we can have: Most notably, we can also show the response, which is particularly interesting in case things go wrong.