### PR TITLE
Prepare `/deploy` for i686-only Pull Requests

### DIFF
--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -188,7 +188,7 @@ module.exports = async (context, req) => {
 
             const toTrigger = []
             if (isMSYSPackage(package_name)) {
-                if (package_name !== 'msys2-runtime-3.3') {
+                if (package_name !== 'msys2-runtime-3.3' && !req.body.issue.title.startsWith('i686:')) {
                     toTrigger.push(
                         { architecture: 'x86_64' }
                     )

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -503,7 +503,6 @@ The workflow run [was started](dispatched-workflow-build-and-deploy.yml).`)
     expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['i686'])
 })
 
-
 testIssueComment('/deploy mingw-w64-clang', {
     issue: {
         number: 75,

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -118,6 +118,9 @@ let mockGitHubApiRequest = jest.fn((_context, _token, method, requestPath, paylo
     if (method === 'GET' && requestPath.endsWith('/pulls/96')) return {
         head: { sha: 'b7b0dfc' }
     }
+    if (method === 'GET' && requestPath.endsWith('/pulls/153')) return {
+        head: { sha: 'b197f8f' }
+    }
     if (method === 'GET' && requestPath.endsWith('/pulls/4322')) return {
         head: { sha: 'c8edb521bdabec14b07e9142e48cab77a40ba339' }
     }
@@ -523,6 +526,28 @@ The workflow run [was started](dispatched-workflow-build-and-deploy.yml).`)
     expect(mockQueueCheckRun).toHaveBeenCalledTimes(1)
     expect(mockUpdateCheckRun).toHaveBeenCalledTimes(1)
     expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['aarch64'])
+})
+
+testIssueComment('/deploy libkbsa', {
+    issue: {
+        number: 153,
+        title: 'i686: build newest version of libksba, because gnupg requires at least v1.6.3',
+        body: 'I just tried to deploy gnupg v2.4.4 but it failed in the deploy-i686 job because of an outdated libksba package. We used to benefit from MSYS2\'s updates, but for the i686 variant there are no more updates of the MSYS packages, therefore we have to build it ourselves now.',
+        pull_request: {
+            html_url: 'https://github.com/git-for-windows/MSYS2-packages/pull/153'
+        }
+    },
+    repository: {
+        name: 'MSYS2-packages'
+    }
+}, async (context) => {
+    expect(await index(context, context.req)).toBeUndefined()
+    expect(context.res.body).toEqual(`I edited the comment: appended-comment-body-existing comment body
+
+The workflow run [was started](dispatched-workflow-build-and-deploy.yml).`)
+    expect(mockQueueCheckRun).toHaveBeenCalledTimes(1)
+    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(1)
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['i686'])
 })
 
 const missingURL = 'https://wingit.blob.core.windows.net/x86-64/mingw-w64-x86_64-git-lfs-3.4.0-1-any.pkg.tar.xz'


### PR DESCRIPTION
It will become increasingly more normal for Git for Windows to be forced to build packages for i686 just because they are dependencies of packages we _want_ to build but a newer dependency version is required (and the MSYS2 project no longer blesses us with i686 variants of MSYS packages).

So let's establish this pattern: If the PR title starts with `i686:`, it is meant only to build and deploy an i686 package, does not require any release notes, and certainly no x86_64 build.

I will use this to deploy the i686 variant of `libkbsa` (which is needed because the newest `gnupg` is no longer happy with version 1.6.0 of that library) in https://github.com/git-for-windows/MSYS2-packages/pull/153.