### PR TITLE
After a Git for Windows version has been released, automatically close the corresponding PR

### DIFF
--- a/GitForWindowsHelper/finalize-g4w-release.js
+++ b/GitForWindowsHelper/finalize-g4w-release.js
@@ -1,0 +1,61 @@
+module.exports = async (context, req) => {
+    if (req.body.action !== 'completed') return "Nothing to do here: workflow run did not complete yet"
+    if (req.body.workflow_run.conclusion !== 'success') return "Nothing to do here: workflow run did not succeed"
+
+    const releaseWorkflowRunID = req.body.workflow_run.id
+    const owner = 'git-for-windows'
+    const repo = 'git'
+    const sender = req.body.sender.login
+
+    const getToken = (() => {
+        let token
+
+        const get = async () => {
+            const getInstallationIdForRepo = require('./get-installation-id-for-repo')
+            const installationId = await getInstallationIdForRepo(context, owner, repo)
+            const getInstallationAccessToken = require('./get-installation-access-token')
+            return await getInstallationAccessToken(context, installationId)
+        }
+
+        return async () => token || (token = await get())
+    })()
+
+    const isAllowed = async (login) => {
+        const getCollaboratorPermissions = require('./get-collaborator-permissions')
+        const token = await getToken()
+        const permission = await getCollaboratorPermissions(context, token, owner, repo, login)
+        return ['ADMIN', 'MAINTAIN', 'WRITE'].includes(permission.toString())
+    }
+
+    if (!await isAllowed(sender)) throw new Error(`${sender} is not allowed to do that`)
+
+    const { searchIssues } = require('./search')
+    const items = await searchIssues(context, 'org:git-for-windows is:pr is:open in:comments "The release-git workflow run was started"')
+
+    const githubApiRequest = require('./github-api-request')
+
+    const needle = `The \`release-git\` workflow run [was started](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/${releaseWorkflowRunID})`
+    const candidates = []
+    for (const item of items) {
+        if (!['OWNER', 'MEMBER'].includes(item.author_association)) continue
+        for (const match of item.text_matches) {
+            const commentURL = match.object_url
+            if (!commentURL.startsWith('https://api.github.com/')) continue
+            const data = await githubApiRequest(context, await getToken(), 'GET', commentURL.substring(22))
+            if (data.body.indexOf(needle) >=0) candidates.push(item)
+        }
+    }
+
+    if (candidates.length !== 1) throw new Error(`Expected 1 candidate PR, got ${candidates.length}`)
+
+    const prNumber = candidates[0].number
+    const pr = await githubApiRequest(context, await getToken(), 'GET', `/repos/${owner}/${repo}/pulls/${prNumber}`)
+    const sha = pr.head.sha
+
+    await githubApiRequest(context, await getToken(), 'PATCH', `/repos/${owner}/${repo}/git/refs/heads/main`, {
+        sha,
+        force: false // require fast-forward
+    })
+
+    return `Took care of pushing the \`main\` branch to close PR ${prNumber}`
+}

--- a/GitForWindowsHelper/index.js
+++ b/GitForWindowsHelper/index.js
@@ -50,6 +50,18 @@ module.exports = async function (context, req) {
     }
 
     try {
+        const finalizeGitForWindowsRelease = require('./finalize-g4w-release')
+        if (req.headers['x-github-event'] === 'workflow_run'
+            && req.body.repository.full_name === 'git-for-windows/git-for-windows-automation'
+            && req.body.action === 'completed'
+            && req.body.workflow_run.path === '.github/workflows/release-git.yml'
+            && req.body.workflow_run.conclusion === 'success') return ok(await finalizeGitForWindowsRelease(context, req))
+    } catch (e) {
+        context.log(e)
+        return withStatus(500, undefined, e.message || JSON.stringify(e, null, 2))
+    }
+
+    try {
         const { cascadingRuns } = require('./cascading-runs.js')
         if (req.headers['x-github-event'] === 'check_run'
             && req.body.repository.full_name === 'git-for-windows/git'

--- a/get-webhook-event-payload.js
+++ b/get-webhook-event-payload.js
@@ -98,7 +98,7 @@
         const events = [...answer.events]
         while (answer.oldest.epoch > since) {
             answer = await getAtCursor(answer.oldest.id - 1)
-            events.push([...answer.events])
+            events.push(...answer.events)
         }
 
         return events

--- a/test-pr-comment-delivery.js
+++ b/test-pr-comment-delivery.js
@@ -26,25 +26,35 @@
         headers: {}
     }
 
-    const payloadOffset = contents.indexOf('\n{')
-    if (payloadOffset < 0) throw new Error(`Could not find start of payload in ${path}`)
-    contents.substring(0, payloadOffset).split(/\r?\n/).forEach(line => {
-        const colon = line.indexOf(':')
-        if (colon < 0) return
+    if (contents.startsWith('event: {')) {
+        const event = JSON.parse(contents.substring(7))
+        Object.keys(event.request.headers).forEach(key => {
+            req.headers[key.toLowerCase()] = event.request.headers[key]
+        })
+        req.body = event.request.payload
+        req.rawBody = JSON.stringify(req.body)
+        req.method = 'POST'
+    } else {
+        const payloadOffset = contents.indexOf('\n{')
+        if (payloadOffset < 0) throw new Error(`Could not find start of payload in ${path}`)
+        contents.substring(0, payloadOffset).split(/\r?\n/).forEach(line => {
+            const colon = line.indexOf(':')
+            if (colon < 0) return
 
-        const key = line.substring(0, colon).toLowerCase()
-        const value = line.substring(colon + 1).replace(/^\s+/, '')
+            const key = line.substring(0, colon).toLowerCase()
+            const value = line.substring(colon + 1).replace(/^\s+/, '')
 
-        if (key === 'request method') req.method = value
-        else req.headers[key] = value
-    })
-    req.rawBody = contents.substring(payloadOffset + 1)
-        // In https://github.com/organizations/git-for-windows/settings/apps/gitforwindowshelper/advanced,
-        // the JSON is pretty-printed, but the actual webhook event avoids any
-        // unnecessary white-space in the body
-        .replace(/\r?\n\s*("[^"]*":)\s*/g, '$1')
-        .replace(/\r?\n\s*/g, '')
-    req.body = JSON.parse(req.rawBody)
+            if (key === 'request method') req.method = value
+            else req.headers[key] = value
+        })
+        req.rawBody = contents.substring(payloadOffset + 1)
+            // In https://github.com/organizations/git-for-windows/settings/apps/gitforwindowshelper/advanced,
+            // the JSON is pretty-printed, but the actual webhook event avoids any
+            // unnecessary white-space in the body
+            .replace(/\r?\n\s*("[^"]*":)\s*/g, '$1')
+            .replace(/\r?\n\s*/g, '')
+        req.body = JSON.parse(req.rawBody)
+    }
 
     const context = {
         log: console.log,


### PR DESCRIPTION
I outlined the idea [here](https://github.com/git-for-windows/git-for-windows-automation/pull/73#issuecomment-1959096816). The gist is:

Let's listen for completed `release-git` workflow runs in the `git-for-windows-automation` repository. The trick is to get from that workflow run to the corresponding `git-for-windows/git` PR because there is no information in the Get a Check Run response to get back to the `git-for-windows/git` PR or tag or commit (example: https://api.github.com/repos/git-for-windows/git-for-windows-automation/actions/runs/7978659901).

Sadly, searching for a PR comment containing the workflow run ID won't work because the REST API search endpoint searches the rendered text, not the Markdown. But we can [search for an open PR with the comment](https://api.github.com/search/issues?q=org:git-for-windows%20is:pr%20is:open%20%22The%20release-git%20workflow%20run%20was%20started%22%20in:comments) and then follow the `comments_url` (e.g. https://api.github.com/repos/git-for-windows/git/issues/4828/comments) that _does_ have that link _and_ has `author_association == 'MEMBER'` (which we need to verify so that we don't fall for jokers who open bogus PRs and add a comment of the exact correct format to throw the automation). By filtering the search results thusly, we should end up with a single candidate for the PR to close.

Finally, retrieve the necessary information from the PR and then use [the `repos/.../git/refs/main` endpoint](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#update-a-reference) endpoint (with `force=false`, to avoid accidental force-pushing). This "pushes" the PR branch to `main`, thereby closing the PR.

My plan is to verify this with the Git for Windows v2.44.0 release that's expected to happen tomorrow.