### PR TITLE
WIP: Automatically close Git for Windows' milestones after a release

### DIFF
--- a/GitForWindowsHelper/milestones.js
+++ b/GitForWindowsHelper/milestones.js
@@ -1,0 +1,36 @@
+const getCurrentMilestone = async (context, token, owner, repo) => {
+    const githubApiRequest = require('./github-api-request')
+    const milestones = await githubApiRequest(context, token, 'GET', `/repos/${owner}/${repo}/milestones?state=open`)
+    if (milestones.length === 2) {
+        const filtered = milestones.filter(m => m.title !== 'Next release')
+        if (filtered.length === 1) milestones.splice(0, 2, filtered)
+    }
+    if (milestones.length !== 1) throw new Error(`Expected one milestone, got ${milestones.length}`)
+    return milestones[0]
+}
+
+const closeMilestone = async (context, token, owner, repo, milestoneNumber, dueOn) => {
+    const githubApiRequest = require('./github-api-request')
+    const payload = {
+        state: 'closed'
+    }
+    if (dueOn) payload.due_on = dueOn
+    await githubApiRequest(context, token, 'PATCH', `/repos/${owner}/${repo}/milestones/${milestoneNumber}`, payload)
+}
+
+const openNextReleaseMilestone = async (context, token, owner, repo) => {
+    const githubApiRequest = require('./github-api-request')
+    const milestones = await githubApiRequest(context, token, 'GET', `/repos/${owner}/${repo}/milestones?state=open`)
+    const filtered = milestones.filter(m => m.title === 'Next release')
+    if (filtered.length === 1) return filtered[0]
+
+    return await githubApiRequest(context, token, 'POST', `/repos/${owner}/${repo}/milestones`, {
+        title: 'Next release'
+    })
+}
+
+module.exports = {
+    getCurrentMilestone,
+    closeMilestone,
+    openNextReleaseMilestone
+}

--- a/test-close-and-open-milestone.js
+++ b/test-close-and-open-milestone.js
@@ -1,0 +1,20 @@
+(async () => {
+    const owner = 'git-for-windows'
+    const repo = 'git'
+
+    const fs = require('fs')
+    const localSettings = JSON.parse(fs.readFileSync('local.settings.json'))
+    Object.entries(localSettings.Values).forEach(([key, value]) => process.env[key] = value)
+
+    const getInstallationIdForRepo = require('./GitForWindowsHelper/get-installation-id-for-repo')
+    const installationId = await getInstallationIdForRepo(console, owner, repo)
+
+    const getInstallationAccessToken = require('./GitForWindowsHelper/get-installation-access-token')
+    const token = await getInstallationAccessToken(console, installationId)
+
+    const { getCurrentMilestone, closeMilestone, openNextReleaseMilestone } = require('./GitForWindowsHelper/milestones')
+    const current = await getCurrentMilestone(console, token, owner, repo)
+    if (current.open_issues > 0) throw new Error(`Milestone ${current.title} has ${current.open_issues} open issue(s)!`)
+    await closeMilestone(console, token, owner, repo, current.number, current.due_on ? false : (new Date()).toISOString())
+    await openNextReleaseMilestone(console, token, owner, repo)
+})().catch(console.log)


### PR DESCRIPTION
This is a work in progress! The idea is that as part of closing a `[New git release]` ticket that is associated with a Git for Windows release, we will close the current milestone and open the next one. The current work-in-progress script was used to successfully close the v2.44.0 milestone and open the `Next release` one. So what's missing? This:

- The current script needs to be replaced by a proper route in `index.js`

- More validations are needed, so that we do not close, say, a milestone that does not even have any issues assigned to it. Or a milestone that is for another version.

- Tests.

This will address
https://github.com/git-for-windows/gfw-helper-github-app/issues/7.