### PR TITLE
Find the `/git-artifacts` comment even more reliably

### DIFF
--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -118,7 +118,14 @@ const cascadingRuns = async (context, req) => {
 
             const token = await getToken(context, checkRunOwner, checkRunRepo)
             const { getGitArtifactsCommentID, appendToIssueComment } = require('./issues')
-            const gitArtifactsCommentID = await getGitArtifactsCommentID(context, token, checkRunOwner, checkRunRepo, req.body.check_run.head_sha)
+            const gitArtifactsCommentID = await getGitArtifactsCommentID(
+                context,
+                token,
+                checkRunOwner,
+                checkRunRepo,
+                req.body.check_run.head_sha,
+                checkRun.details_url,
+            )
 
             if (gitArtifactsCommentID) {
                 await appendToIssueComment(context, token, checkRunOwner, checkRunRepo, gitArtifactsCommentID, comment)

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -150,12 +150,12 @@ let mockGitHubApiRequest = jest.fn((_context, _token, method, requestPath, paylo
         }]
     }
     if (method === 'GET' && requestPath === '/repos/git-for-windows/git/issues/comments/1450703020') return {
-        body: '/git-artifacts\n\nThe tag-git workflow run [was started](https://url-to-tag-git/)'
+        body: '/git-artifacts\n\nThe `tag-git` workflow run [was started](https://url-to-tag-git/)'
     }
     if (method === 'PATCH' && requestPath === '/repos/git-for-windows/git/issues/comments/1450703020') {
         expect(payload.body).toEqual(`/git-artifacts
 
-The tag-git workflow run [was started](https://url-to-tag-git/)
+The \`tag-git\` workflow run [was started](https://url-to-tag-git/)
 
 git-artifacts-x86_64 run already exists at <url-to-existing-x86_64-run>.
 The \`git-artifacts-i686\` workflow run [was started](dispatched-workflow-git-artifacts.yml).
@@ -635,6 +635,7 @@ test('a completed `tag-git` run triggers `git-artifacts` runs', async () => {
             name: 'tag-git',
             head_sha: 'c8edb521bdabec14b07e9142e48cab77a40ba339',
             conclusion: 'success',
+            details_url: 'https://url-to-tag-git/',
             output: {
                 title: 'Tag Git v2.40.0-rc1.windows.1 @c8edb521bdabec14b07e9142e48cab77a40ba339',
                 summary: 'Tag Git v2.40.0-rc1.windows.1 @c8edb521bdabec14b07e9142e48cab77a40ba339',


### PR DESCRIPTION
Over in https://github.com/git-for-windows/git/pull/4918, _something_ in the range-diff was matched _somehow_ by that search string. The `text_matches` of the returned objects look like this:

```yaml
  text_matches: [
    {
      object_url: "https://api.github.com/repositories/23216272/issues/comments/2067288321",
      object_type: "IssueComment",
      property: "body",
      fragment: "/git-artifacts\n\nThe tag-git workflow run was started\n",
      matches: [
        {
          text: "git",
          indices: [
            1,
            4,
          ],
        },
        {
          text: "artifacts",
          indices: [
            5,
            14,
          ],
        },
        {
          text: "git",
          indices: [
            24,
            27,
          ],
        },
      ],
    },
    {
      object_url: "https://api.github.com/repositories/23216272/issues/4918",
      object_type: "Issue",
      property: "body",
      fragment: " = 53: 33d9a68ea63 vcxproj: handle GUI programs, too\n\n  - 55: 417ce96c240 = 54: 4c3acea6c21 ci(vs-build) also build Windows/ARM64 artifacts\n\n  - 52: d044e202fa2 = 55: ac6ad169b01 cmake: install",
      matches: [
        {
          text: "artifacts",
          indices: [
            130,
            139,
          ],
        },
      ],
    },
  ],
```

In other words, there is not even the word "git" in the matches, and we'll just have to deal with this possible scenario.