### PR TITLE
self-hosted-arm64-runners: specify target repo

### DIFF
--- a/GitForWindowsHelper/self-hosted-arm64-runners.js
+++ b/GitForWindowsHelper/self-hosted-arm64-runners.js
@@ -47,7 +47,9 @@ module.exports = async (context, req) => {
             'git-for-windows-automation',
             'create-azure-self-hosted-runners.yml',
             'main', {
-                runner_scope: 'repo-level'
+                runner_scope: 'repo-level',
+                // Repository that the runner will be deployed to. We want to ensure that the runner is deployed to the same repository that triggered the action.
+                runner_repo: repo
             }
         )
 


### PR DESCRIPTION
The create-azure-self-hosted-runners workflow has an input called `runner_repo` which can be used to specify the repository that the runner will be deployed to. It defaults to git-for-windows-automation, which is not the right one in all cases.

Let's set the `runner_repo` input to the repository that requested the runner.

Ref: https://github.com/git-for-windows/git-for-windows-automation/blob/main/.github/workflows/create-azure-self-hosted-runners.yml#L18C7-L18C18