### PR TITLE
Fix `/updpkgsums`

### DIFF
--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -124,7 +124,7 @@ module.exports = async (context, req) => {
                 'updpkgsums.yml',
                 'main', {
                     repo,
-                    'pr-number': issueNumber,
+                    'pr-number': '' + issueNumber,
                     actor: commenter
                 }
             );

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -354,7 +354,7 @@ The workflow run [was started](dispatched-workflow-updpkgsums.yml).`,
     expect(mockGetInstallationAccessToken).toHaveBeenCalledTimes(1)
     expect(mockGitHubApiRequestAsApp).not.toHaveBeenCalled()
     expect(dispatchedWorkflows).toHaveLength(1)
-    expect(dispatchedWorkflows.map(e => e.payload.inputs['pr-number'])).toEqual([104])
+    expect(dispatchedWorkflows.map(e => e.payload.inputs['pr-number'])).toEqual(['104'])
     expect(mockGitHubApiRequest).toHaveBeenCalled()
     const comment = mockGitHubApiRequest.mock.calls[mockGitHubApiRequest.mock.calls.length - 1]
     expect(comment[3]).toEqual('/repos/git-for-windows/MINGW-packages/issues/comments/0')

--- a/get-webhook-event-payload.js
+++ b/get-webhook-event-payload.js
@@ -11,6 +11,16 @@
     while (args.length) {
         let option = args.shift()
 
+        const issueCommentMatch = option.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/\d+#issuecomment-(\d+)$/)
+        if (issueCommentMatch) {
+            eventType = 'issue_comment'
+            const githubRequest = require('./GitForWindowsHelper/github-api-request')
+            const [owner, repo, comment_id] = issueCommentMatch.slice(1)
+            const comment = await githubRequest(console, null, 'GET', `/repos/${owner}/${repo}/issues/comments/${comment_id}`)
+            aroundDate = new Date(comment.updated_at)
+            continue
+        }
+
         const optionWithArgument = option.match(/^(--[^=]+)=(.*)$/)
         if (optionWithArgument) {
             option = optionWithArgument[1]

--- a/get-webhook-event-payload.js
+++ b/get-webhook-event-payload.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 (async () => {
     const fs = require('fs')
 


### PR DESCRIPTION
Even after https://github.com/git-for-windows/git-for-windows-automation/pull/82, [the `/updpkgsums` call](https://github.com/git-for-windows/build-extra/pull/558#issuecomment-2154366214) over in https://github.com/git-for-windows/build-extra/pull/558 failed.

While this PR won't fix it completely, it fixes the GitForWindowsHelper GitHub App side of it.