### PR TITLE
`/open pr`: support running in git-for-windows/msys2-runtime PRs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
       "args": ["--runInBand", "--config", "jest.config.js"],
       "windows": {
         "program": "${workspaceFolder}/node_modules/jest/bin/jest"
-      }
+      },
+      "console": "integratedTerminal"
     },
     {
       "name": "Attach to Node Functions",

--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -2,6 +2,7 @@ const guessComponentUpdateDetails = (title, body) => {
     let [ , package_name, version ] =
         title.match(/^\[New (\S+) version\] (?:[^0-9]+\s+)?(\S+(?:\s+patch\s+\d+)?)(?! new items)/) ||
         title.match(/^(\S+): update to v?(\d[0-9.]\S*)/) ||
+        title.match(/^(msys2-runtime): update to ([0-9a-f]{40,64})/) ||
         body.match(/^# \[New (\S+) version\] (?:[^0-9]+\s+)?(\S+(?:\s+patch\s+\d+)?)/) ||
         []
     if (!package_name || !version) throw new Error(`Could not guess component-update details from title '${title}'`)

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -50,12 +50,18 @@ module.exports = async (context, req) => {
 
     try {
         if (command == '/open pr') {
-            if (owner !== 'git-for-windows' || repo !== 'git') return `Ignoring ${command} in unexpected repo: ${commentURL}`
+            if (owner !== 'git-for-windows' || !['git', 'msys2-runtime'].includes(repo)) return `Ignoring ${command} in unexpected repo: ${commentURL}`
 
             await checkPermissions()
 
             const { guessComponentUpdateDetails, packageNeedsBothMSYSAndMINGW } = require('./component-updates')
-            const { package_name, version } = guessComponentUpdateDetails(req.body.issue.title, req.body.issue.body)
+            const { getPRCommitSHA } = require('./issues')
+            const { package_name, version } = repo === 'msys2-runtime'
+                ? {
+                    package_name: repo,
+                    version: await getPRCommitSHA(context, await getToken(), owner, repo, issueNumber)
+                }
+                : guessComponentUpdateDetails(req.body.issue.title, req.body.issue.body)
 
             await thumbsUp()
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -139,6 +139,9 @@ let mockGitHubApiRequest = jest.fn((_context, _token, method, requestPath, paylo
     if (method === 'GET' && requestPath.endsWith('/pulls/69')) return {
         head: { sha: '59d71150a6ee93ab954221c43ca86f8eafe68ddc'}
     }
+    if (method === 'GET' && requestPath.endsWith('/pulls/177')) return {
+        head: { sha: '03bdffe5997'}
+    }
     if (method === 'PATCH' && requestPath.endsWith('/git/refs/heads/main')) {
         if (payload.sha !== 'c0ffee1ab7e') throw new Error(`Unexpected sha: ${payload.sha}`)
         if (payload.force !== false) throw new Error(`Unexpected force value: ${payload.force}`)
@@ -543,6 +546,29 @@ The workflow run [was started](dispatched-workflow-build-and-deploy.yml).`)
     expect(mockQueueCheckRun).toHaveBeenCalledTimes(1)
     expect(mockUpdateCheckRun).toHaveBeenCalledTimes(1)
     expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['x86_64'])
+})
+
+testIssueComment('/deploy', {
+    issue: {
+        number: 177,
+        title: 'msys2-runtime: update to 4b3a2e08f545432b62461313082193d6df09b6b8',
+        body: 'This corresponds to https://github.com/git-for-windows/msys2-runtime/pull/70',
+        pull_request: {
+            html_url: 'https://github.com/git-for-windows/MSYS2-packages/pull/177'
+        }
+    },
+    repository: {
+        name: 'MSYS2-packages'
+    }
+}, async (context) => {
+    expect(await index(context, context.req)).toBeUndefined()
+    expect(context.res.body).toEqual(`I edited the comment: appended-comment-body-existing comment body
+
+The workflow run [was started](dispatched-workflow-build-and-deploy.yml).`)
+    expect(mockQueueCheckRun).toHaveBeenCalledTimes(1)
+    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(1)
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['x86_64'])
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.package)).toEqual(['msys2-runtime'])
 })
 
 testIssueComment('/deploy msys2-runtime-3.3', {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -136,6 +136,9 @@ let mockGitHubApiRequest = jest.fn((_context, _token, method, requestPath, paylo
     if (method === 'GET' && requestPath.endsWith('/pulls/765')) return {
         head: { sha: 'c0ffee1ab7e' }
     }
+    if (method === 'GET' && requestPath.endsWith('/pulls/69')) return {
+        head: { sha: '59d71150a6ee93ab954221c43ca86f8eafe68ddc'}
+    }
     if (method === 'PATCH' && requestPath.endsWith('/git/refs/heads/main')) {
         if (payload.sha !== 'c0ffee1ab7e') throw new Error(`Unexpected sha: ${payload.sha}`)
         if (payload.force !== false) throw new Error(`Unexpected force value: ${payload.force}`)
@@ -327,6 +330,44 @@ The MSYS workflow run [was started](dispatched-workflow-open-pr.yml)`
         body: `existing comment body
 
 The MINGW workflow run [was started](dispatched-workflow-open-pr.yml)`
+    })
+})
+
+testIssueComment('/open pr', {
+    repository: {
+        name: 'msys2-runtime'
+    },
+    issue: {
+        number: 69,
+        title: 'Support OneDrive better',
+        body: `This backports patches that avoid hydrating files on OneDrive _just_ to \`stat()\` them.
+
+See also https://github.com/msys2/msys2-runtime/issues/206.`,
+        pull_request: {
+            html_url: 'https://github.com/git-for-windows/msys2-runtime/pull/69'
+        }
+    }
+}, async (context) => {
+    expect(await index(context, context.req)).toBeUndefined()
+    expect(context.res).toEqual({
+        body: `I edited the comment: appended-comment-body-existing comment body
+
+The workflow run [was started](dispatched-workflow-open-pr.yml)`,
+        headers: undefined,
+        status: undefined
+    })
+    expect(mockGetInstallationAccessToken).toHaveBeenCalledTimes(1)
+    expect(mockGitHubApiRequestAsApp).not.toHaveBeenCalled()
+    expect(dispatchedWorkflows).toHaveLength(1)
+    expect(dispatchedWorkflows[0].payload.inputs.package).toEqual('msys2-runtime')
+    expect(dispatchedWorkflows[0].payload.inputs.version).toEqual('59d71150a6ee93ab954221c43ca86f8eafe68ddc')
+    expect(mockGitHubApiRequest).toHaveBeenCalled()
+    const msysComment = mockGitHubApiRequest.mock.calls[mockGitHubApiRequest.mock.calls.length - 1]
+    expect(msysComment[3]).toEqual('/repos/git-for-windows/msys2-runtime/issues/comments/0')
+    expect(msysComment[4]).toEqual({
+        body: `existing comment body
+
+The workflow run [was started](dispatched-workflow-open-pr.yml)`
     })
 })
 


### PR DESCRIPTION
This is the logical companion to https://github.com/git-for-windows/git-for-windows-automation/pull/87.

The idea is that PRs like https://github.com/git-for-windows/msys2-runtime/pull/69 can be integrated easily via running `/open pr` and then, in the newly-created PR, running `/deploy`.