### PR TITLE
Teach the app about InnoSetup

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -14,7 +14,7 @@ const guessComponentUpdateDetails = (title, body) => {
     else if (['clang', 'llvm', 'mingw-w64-clang'].includes(package_name)) package_name = 'mingw-w64-llvm'
 
     version = version
-        .replace(/^(GCM |openssl-|OpenSSL_|v|V_|GnuTLS |tig-|Heimdal |cygwin-|PCRE2-|Bash-|curl-|gnupg-)/, '')
+        .replace(/^(GCM |openssl-|OpenSSL_|v|V_|GnuTLS |tig-|Heimdal |cygwin-|PCRE2-|Bash-|curl-|gnupg-|is-)/, '')
         .replace(/\s+patch\s+/, '.')
         .replace(/_/g, '.')
         .replace(/-release$/, '')
@@ -38,6 +38,7 @@ const prettyPackageName = (name) => {
         pcre2: 'PCRE2',
         perl: 'Perl',
         tig: 'Tig',
+        innosetup: 'InnoSetup',
     }[name] || name
 }
 

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -37,7 +37,8 @@ test('guessComponentUpdateDetails()', () => {
         ['[New heimdal version] Heimdal 7.7.1 - Security Fix Release', 'heimdal', '7.7.1'],
         ['[New gnutls version] GnuTLS 3.8.0', 'gnutls', '3.8.0'],
         ['[New git-credential-manager version] GCM 2.0.886', 'mingw-w64-git-credential-manager', '2.0.886'],
-        ['[New gpg version] gnupg-2.2.42', 'gnupg', '2.2.42']
+        ['[New gpg version] gnupg-2.2.42', 'gnupg', '2.2.42'],
+        ['[New innosetup version] is-6_3_3', 'innosetup', '6.3.3'],
     ]
     for (const [title, package_name, version] of titles) {
         expect(guessComponentUpdateDetails(title)).toEqual({ package_name, version })


### PR DESCRIPTION
Git for Windows now also receives new tickets whenever a new InnoSetup version has been tagged. Therefore it makes sense to teach the `/open pr` machinery about this component, too.

Note that the `open-pr` GitHub workflow also needs to be adjusted slightly, I have patches in hand but could not validate them yet because [the new InnoSetup installer is not yet available for download](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/9907166552/job/27370261636#step:9:44).

EDIT: The `open-pr` GitHub workflow is updated [here](https://github.com/git-for-windows/git-for-windows-automation/pull/88).