### PR TITLE
guess release notes: special-case cURL (even in MINGW-packages)

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -102,11 +102,13 @@ const guessReleaseNotes = async (context, issue) => {
     }
 
     const matchURL = async () => {
-        if (package_name === 'perl') return `http://search.cpan.org/dist/perl-${version}/pod/perldelta.pod`
-        if (package_name === 'curl') return `https://curl.se/changes.html#${version.replaceAll('.', '_')}`
-        if (package_name === 'openssl') return `https://www.openssl.org/news/openssl-${
+        switch (package_name.replace(/^mingw-w64-/, '')) {
+        case 'perl': return `http://search.cpan.org/dist/perl-${version}/pod/perldelta.pod`
+        case 'curl': return `https://curl.se/changes.html#${version.replaceAll('.', '_')}`
+        case 'openssl': return `https://www.openssl.org/news/openssl-${
             version.replace(/^(1\.1\.1|[3-9]\.\d+).*/, '$1')
         }-notes.html`
+        }
 
         if (!issue.pull_request) return matchURLInIssue(issue)
 

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -151,6 +151,17 @@ http://www.gnutls.org/news.html#2023-02-10`
     })
 
     expect(await guessReleaseNotes(context, {
+        pull_request: { "html_url": "https://github.com/git-for-windows/MINGW-packages/pull/120" },
+        title: 'mingw-w64-curl: update to 8.8.0',
+        body: `This closes https://github.com/git-for-windows/git/issues/4963`
+    })).toEqual({
+        type: 'feature',
+        message: 'Comes with [cURL v8.8.0](https://curl.se/changes.html#8_8_0).',
+        package: 'mingw-w64-curl',
+        version: '8.8.0'
+    })
+
+    expect(await guessReleaseNotes(context, {
         labels: [{ name: 'component-update' }],
         title: '[New openssl version] OpenSSL 1.1.1u',
         body: `\nhttps://github.com/openssl/openssl/releases/tag/OpenSSL_1_1_1u`


### PR DESCRIPTION
In https://github.com/git-for-windows/gfw-helper-github-app/pull/34, I taught the GitForWindowsHelper GitHub App to generate better release notes for cURL.

However, I failed to notice that the code changes would work only for the `component-updates` issues as well as for the MSYS2-packages PRs, but not for the MINGW-packages PRs because the package name that is derived from the latter PRs has the `mingw-w64-` prefix (and must have it, for the "is this already deployed?" check).

Let's make sure that that special-casing (as well for cURL as well as for OpenSSL) work even in MINGW-packages PRs.