### PR TITLE
slash-commands: support arm64 in release command

### DIFF
--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -400,7 +400,7 @@ module.exports = async (context, req) => {
                 let gitVersion
                 let tagGitWorkflowRunID
                 const workFlowRunIDs = {}
-                for (const architecture of ['x86_64', 'i686']) {
+                for (const architecture of ['x86_64', 'i686', 'aarch64']) {
                     const workflowName = `git-artifacts-${architecture}`
                     const runs = await listCheckRunsForCommit(
                         context,
@@ -447,7 +447,7 @@ module.exports = async (context, req) => {
                     releaseCheckRunId, {
                         output: {
                             title: `Publish ${gitVersion} for @${commitSHA}`,
-                            summary: `Downloading the Git artifacts from ${workFlowRunIDs['x86_64']} and ${workFlowRunIDs['i686']} and publishing them as a new GitHub Release at ${owner}/${repo}`
+                            summary: `Downloading the Git artifacts from ${workFlowRunIDs['x86_64']}, ${workFlowRunIDs['i686']} and ${workFlowRunIDs['aarch64']} and publishing them as a new GitHub Release at ${owner}/${repo}`
                         }
                     }
                 )
@@ -461,7 +461,8 @@ module.exports = async (context, req) => {
                     'release-git.yml',
                     'main', {
                         git_artifacts_x86_64_workflow_run_id: workFlowRunIDs['x86_64'],
-                        git_artifacts_i686_workflow_run_id: workFlowRunIDs['i686']
+                        git_artifacts_i686_workflow_run_id: workFlowRunIDs['i686'],
+                        git_artifacts_aarch64_workflow_run_id: workFlowRunIDs['aarch64'],
                     }
                 )
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -413,7 +413,11 @@ let mockQueueCheckRun = jest.fn(() => 'check-run-id')
 let mockUpdateCheckRun = jest.fn()
 let mockListCheckRunsForCommit = jest.fn((_context, _token, _owner, _repo, rev, checkRunName) => {
     if (rev === 'this-will-be-rc2') {
-        const id = checkRunName === 'git-artifacts-x86_64' ? 8664 : 686
+        const id = {
+            'git-artifacts-x86_64': 8664,
+            'git-artifacts-i686': 686,
+            'git-artifacts-aarch64': 64
+        }[checkRunName]
         const output = {
             title: 'Build Git -rc2 artifacts',
             summary: 'Build Git -rc2 artifacts from commit this-will-be-rc2 (tag-git run #987)',
@@ -861,7 +865,8 @@ The \`release-git\` workflow run [was started](dispatched-workflow-release-git.y
     expect(dispatchedWorkflows[0].html_url).toEqual('dispatched-workflow-release-git.yml')
     expect(dispatchedWorkflows[0].payload.inputs).toEqual({
         git_artifacts_x86_64_workflow_run_id: "8664",
-        git_artifacts_i686_workflow_run_id: "686"
+        git_artifacts_i686_workflow_run_id: "686",
+        git_artifacts_aarch64_workflow_run_id: "64"
     })
 })
 


### PR DESCRIPTION
We're already building arm64 artifacts, so let's add support for arm64 to the release pipeline as well. Note: this needs the workflow to support the `git_artifacts_aarch64_workflow_run_id` input as well.