### PR TITLE
Add a slash command to synchronize Git for Windows' SDK repositories

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,8 @@
         "gnutls",
         "Heimdal",
         "MSYS",
-        "relnote"
+        "relnote",
+        "updpkgsums"
     ],
     "cSpell.ignoreRegExpList": [
         "AZURE_FUNCTIONAPP_PUBLISH_PROFILE",

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -49,7 +49,7 @@ module.exports = async (context, req) => {
     const thumbsUp = async () => react('+1')
 
     try {
-        if (command == '/open pr') {
+        if (command === '/open pr') {
             if (owner !== 'git-for-windows' || !['git', 'msys2-runtime'].includes(repo)) return `Ignoring ${command} in unexpected repo: ${commentURL}`
 
             await checkPermissions()
@@ -111,7 +111,7 @@ module.exports = async (context, req) => {
             return `I edited the comment: ${commentURL}`
         }
 
-        if (command == '/updpkgsums') {
+        if (command === '/updpkgsums') {
             if (owner !== 'git-for-windows'
              || !req.body.issue.pull_request
              || !['build-extra', 'MINGW-packages', 'MSYS2-packages'].includes(repo)) {
@@ -265,7 +265,7 @@ module.exports = async (context, req) => {
             return `I edited the comment: ${answer.html_url}`
         }
 
-        if (command == '/git-artifacts') {
+        if (command === '/git-artifacts') {
             if (owner !== 'git-for-windows'
              || repo !== 'git'
              || !req.body.issue.pull_request
@@ -367,7 +367,7 @@ module.exports = async (context, req) => {
             }
         }
 
-        if (command == '/release') {
+        if (command === '/release') {
             if (owner !== 'git-for-windows'
               || repo !== 'git'
               || !req.body.issue.pull_request

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ For convenience, the command can be abbreviated as `/add relnote <type> <message
 
 **What does it do?** This triggers one ore more [GitHub workflow runs](https://github.com/git-for-windows/git-for-windows-automation/actions/workflows/build-and-deploy.yml) to build and deploy Git for Windows' [Pacman packages](https://github.com/git-for-windows/git/wiki/Package-management).
 
+### `/synchronize-sdks`
+
+**Where can it be called?** In Issues and Pull Requests of Git for Windows' repositories.
+
+**What does it do?** This triggers the `sync` GitHub workflow runs in Git for Windows' `git-sdk-*` repositories, i.e. updates them with the newest package versions as per the Pacman repositories.
+
 ### `/git-artifacts`
 
 **Where can it be called?** In `git-for-windows/git`'s [Pull Requests](https://github.com/git-for-windows/git/pulls)


### PR DESCRIPTION
Every once in a while I need to ensure that the packages that were just deployed via a `/deploy` command are integrated into the respective `git-sdk-*` repositories so that a subsequent `/git-artifacts` run will pick up the just-deployed package versions.

This PR adds the convenient `/sync` command for that, which [I just used successfully](https://github.com/git-for-windows/MSYS2-packages/pull/211#issuecomment-2624294399) (running this PR's code locally because it is obviously not yet deployed to the Azure Function).