### PR TITLE
Fix the snapshot uploading of official Git for Windows versions

### DIFF
--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -166,7 +166,7 @@ const cascadingRuns = async (context, req) => {
 
             // Next, check that the commit is on the `main` branch
             const gitToken = await getToken(context, checkRunOwner, checkRunRepo)
-            const { ahead_by } = await githubApiRequest(
+            const { ahead_by, behind_by } = await githubApiRequest(
                 context,
                 gitToken,
                 'GET',
@@ -174,7 +174,7 @@ const cascadingRuns = async (context, req) => {
                 // `/repos/dscho/git/compare/HEAD...${commit}`,
             )
             if (ahead_by > 0) {
-                return `Ignoring ${name} check-run because its corresponding commit ${commit} is not on the main branch`
+                return `Ignoring ${name} check-run because its corresponding commit ${commit} is not on the main branch (ahead by ${ahead_by}, behind by ${behind_by})`
             }
 
             const workFlowRunIDs = {}
@@ -246,7 +246,7 @@ const cascadingRuns = async (context, req) => {
                 }
             )
 
-            return `The 'upload-snapshot' workflow run was started at ${answer.html_url}`
+            return `The 'upload-snapshot' workflow run was started at ${answer.html_url} (ahead by ${ahead_by}, behind by ${behind_by})`
         }
         return `Not a cascading run: ${name}; Doing nothing.`
     }

--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -166,13 +166,14 @@ const cascadingRuns = async (context, req) => {
 
             // Next, check that the commit is on the `main` branch
             const gitToken = await getToken(context, checkRunOwner, checkRunRepo)
-            const { behind_by } = await githubApiRequest(
+            const { ahead_by } = await githubApiRequest(
                 context,
                 gitToken,
                 'GET',
                 `/repos/${checkRunOwner}/${checkRunRepo}/compare/HEAD...${commit}`,
+                // `/repos/dscho/git/compare/HEAD...${commit}`,
             )
-            if (behind_by > 0) {
+            if (ahead_by > 0) {
                 return `Ignoring ${name} check-run because its corresponding commit ${commit} is not on the main branch`
             }
 

--- a/GitForWindowsHelper/finalize-g4w-release.js
+++ b/GitForWindowsHelper/finalize-g4w-release.js
@@ -58,5 +58,20 @@ module.exports = async (context, req) => {
         force: false // require fast-forward
     })
 
-    return `Took care of pushing the \`main\` branch to close PR ${prNumber}`
+    // trigger "upload artifacts" workflow
+    const { handlePush } = require('./cascading-runs')
+    const uploadSnapshotAnswer = await handlePush(context, {
+        body: {
+            repository: {
+                owner: {
+                    login: owner,
+                },
+                name: repo,
+            },
+            ref: 'refs/heads/main',
+            after: sha,
+        }
+    })
+
+    return `Took care of pushing the \`main\` branch to close PR ${prNumber}\n${uploadSnapshotAnswer}`
 }

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -943,11 +943,14 @@ test('a completed `release-git` run updates the `main` branch in git-for-windows
     try {
         expect(await index(context, context.req)).toBeUndefined()
         expect(context.res).toEqual({
-            body: `Took care of pushing the \`main\` branch to close PR 765`,
+            body: [
+                'Took care of pushing the `main` branch to close PR 765',
+                `The 'tag-git' workflow run was started at dispatched-workflow-tag-git.yml`,
+            ].join('\n'),
             headers: undefined,
             status: undefined
         })
-        expect(mockGitHubApiRequest).toHaveBeenCalledTimes(4)
+        expect(mockGitHubApiRequest).toHaveBeenCalledTimes(7)
         expect(mockGitHubApiRequest.mock.calls[3].slice(1)).toEqual([
             'installation-access-token',
             'PATCH',

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -175,7 +175,7 @@ The \`git-artifacts-aarch64\` workflow run [was started](dispatched-workflow-git
     }
     if (method === 'GET' && requestPath ===
         '/repos/git-for-windows/git/compare/HEAD...0c796d3013a57e8cc894c152f0200107226e5dd1') {
-        return { ahead_by: 0 }
+        return { ahead_by: 0, behind_by: 99 }
     }
     throw new Error(`Unhandled ${method}-${requestPath}-${JSON.stringify(payload)}`)
 })
@@ -994,7 +994,7 @@ test('the third completed `git-artifacts-<arch>` check-run triggers an `upload-s
     try {
         expect(await index(context, context.req)).toBeUndefined()
         expect(context.res).toEqual({
-            body: `The 'upload-snapshot' workflow run was started at dispatched-workflow-upload-snapshot.yml`,
+            body: `The 'upload-snapshot' workflow run was started at dispatched-workflow-upload-snapshot.yml (ahead by 0, behind by 99)`,
             headers: undefined,
             status: undefined
         })

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -175,7 +175,7 @@ The \`git-artifacts-aarch64\` workflow run [was started](dispatched-workflow-git
     }
     if (method === 'GET' && requestPath ===
         '/repos/git-for-windows/git/compare/HEAD...0c796d3013a57e8cc894c152f0200107226e5dd1') {
-        return { behind_by: 0 }
+        return { ahead_by: 0 }
     }
     throw new Error(`Unhandled ${method}-${requestPath}-${JSON.stringify(payload)}`)
 })


### PR DESCRIPTION
When publishing Git for Windows v2.48.1, two bugs became obvious:

- Directly after `/git-artifacts` finished, the `upload-snapshot` workflow was run, and [it failed](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/13307618060/job/37162142657#step:7:43) (because it was started before I could even validate the installers let alone release them, and therefore the corresponding commit was not yet reachable from `main`).
- When I finally was ready to `/release`, everything worked fine except that the `upload-snapshot` run was _not_ triggered (I had to manually trigger [a re-run](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/13307618060/job/37164420059) of the previously-canceled one to upload [the snapshot](https://github.com/git-for-windows/git-snapshots/releases/tag/2.48.1)).

This here Pull Request fixes both issues.