### PR TITLE
Fix `upload-snapshot` on `push`

### DIFF
--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -344,6 +344,10 @@ const handlePush = async (context, req) => {
     if (!match[2] === commit) throw new Error(`Unexpected revision ${match[2]} '${latest.output.summary}' of tag-git run: ${latest.html_url}`)
     const ver = match[1]
 
+    const match2 = latest.output.text.match(/^For details, see \[this run\]\(https:\/\/github.com\/([^/]+)\/([^/]+)\/actions\/runs\/(\d+)\)/)
+    if (!match2) throw new Error(`Unexpected summary '${latest.output.summary}' of tag-git run: ${latest.html_url}`)
+    const [, , , tagGitWorkflowRunId] = match2
+
     // There is already a `tag-git` workflow run; Is there already an `upload-snapshot` run?
     const latestUploadSnapshotRun = (await listCheckRunsForCommit(
         context,
@@ -381,7 +385,7 @@ const handlePush = async (context, req) => {
                 workflowName
             )
             const needle =
-                `Build Git ${ver} artifacts from commit ${commit} (tag-git run #${latest.id})`
+                `Build Git ${ver} artifacts from commit ${commit} (tag-git run #${tagGitWorkflowRunId})`
             const latest2 = runs
                 .filter(run => run.output.summary === needle)
                 .sort((a, b) => a.id - b.id)

--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -413,7 +413,7 @@ const handlePush = async (context, req) => {
         const answer = await triggerWorkflowDispatch(
             context,
             gitForWindowsAutomationToken,
-            pushRepo,
+            pushOwner,
             'git-for-windows-automation',
             'upload-snapshot.yml',
             'main', {

--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -354,7 +354,7 @@ const handlePush = async (context, req) => {
     const tagGitCheckRunTitle = `Upload snapshot Git @${commit}`
     const tagGitCheckRunId = await queueCheckRun(
         context,
-        await getToken(),
+        await getToken(context, pushOwner, pushRepo),
         pushOwner,
         pushRepo,
         commit,

--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -339,6 +339,11 @@ const handlePush = async (context, req) => {
         `The 'tag-git' run at ${latest.html_url} did not succeed (conclusion = ${latest.conclusion}).`
     )
 
+    const match = latest.output.summary.match(/^Tag Git (\S+) @([0-9a-f]+)$/)
+    if (!match) throw new Error(`Unexpected summary '${latest.output.summary}' of tag-git run: ${latest.html_url}`)
+    if (!match[2] === commit) throw new Error(`Unexpected revision ${match[2]} '${latest.output.summary}' of tag-git run: ${latest.html_url}`)
+    const ver = match[1]
+
     // There is already a `tag-git` workflow run; Is there already an `upload-snapshot` run?
     const latestUploadSnapshotRun = (await listCheckRunsForCommit(
         context,
@@ -362,11 +367,6 @@ const handlePush = async (context, req) => {
         tagGitCheckRunTitle,
         tagGitCheckRunTitle
     )
-
-    const match = latest.output.summary.match(/^Tag Git (\S+) @([0-9a-f]+)$/)
-    if (!match) throw new Error(`Unexpected summary '${latest.output.summary}' of tag-git run: ${latest.html_url}`)
-    if (!match[2] === commit) throw new Error(`Unexpected revision ${match[2]} '${latest.output.summary}' of tag-git run: ${latest.html_url}`)
-    const ver = match[1]
 
     try {
         const workFlowRunIDs = {}

--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -358,7 +358,7 @@ const handlePush = async (context, req) => {
         pushOwner,
         pushRepo,
         commit,
-        'tag-git',
+        'upload-snapshot',
         tagGitCheckRunTitle,
         tagGitCheckRunTitle
     )

--- a/GitForWindowsHelper/check-runs.js
+++ b/GitForWindowsHelper/check-runs.js
@@ -1,4 +1,7 @@
 const queueCheckRun = async (context, token, owner, repo, ref, checkRunName, title, summary) => {
+    if ('true' === process.env.DO_NOT_TRIGGER_ANYTHING) {
+        throw new Error(`Would have queued Check Run ${checkRunName} in ${owner}/${repo} with ref ${ref}`)
+    }
     const githubApiRequest = require('./github-api-request')
     // is there an existing check-run we can re-use?
     const { check_runs } = await githubApiRequest(
@@ -47,6 +50,9 @@ const queueCheckRun = async (context, token, owner, repo, ref, checkRunName, tit
 }
 
 const updateCheckRun = async (context, token, owner, repo, checkRunId, parameters) => {
+    if ('true' === process.env.DO_NOT_TRIGGER_ANYTHING) {
+        throw new Error(`Would have updated Check Run ${checkRunId} in ${owner}/${repo} with parameters ${JSON.stringify(parameters)}`)
+    }
     const githubApiRequest = require('./github-api-request')
 
     await githubApiRequest(
@@ -59,6 +65,9 @@ const updateCheckRun = async (context, token, owner, repo, checkRunId, parameter
 }
 
 const cancelWorkflowRun = async (context, token, owner, repo, workflowRunId) => {
+    if ('true' === process.env.DO_NOT_TRIGGER_ANYTHING) {
+        throw new Error(`Would have canceled workflow run ${workflowRunId} in ${owner}/${repo}`)
+    }
     const githubApiRequest = require('./github-api-request')
 
     const answer = await githubApiRequest(

--- a/GitForWindowsHelper/finalize-g4w-release.js
+++ b/GitForWindowsHelper/finalize-g4w-release.js
@@ -58,20 +58,5 @@ module.exports = async (context, req) => {
         force: false // require fast-forward
     })
 
-    // trigger "upload artifacts" workflow
-    const { handlePush } = require('./cascading-runs')
-    const uploadSnapshotAnswer = await handlePush(context, {
-        body: {
-            repository: {
-                owner: {
-                    login: owner,
-                },
-                name: repo,
-            },
-            ref: 'refs/heads/main',
-            after: sha,
-        }
-    })
-
-    return `Took care of pushing the \`main\` branch to close PR ${prNumber}\n${uploadSnapshotAnswer}`
+    return `Took care of pushing the \`main\` branch to close PR ${prNumber}`
 }

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -465,9 +465,10 @@ let mockListCheckRunsForCommit = jest.fn((_context, _token, _owner, _repo, rev, 
             conclusion: 'success',
             status: 'completed',
             output: {
-                summary: 'Tag Git already-tagged @88811'
+                summary: 'Tag Git already-tagged @88811',
+                text: 'For details, see [this run](https://github.com/x/y/actions/runs/123).\nTagged already-tagged\nDone!.'
             },
-            id: 123
+            id: 123456789
         }]
         if (checkRunName.startsWith('git-artifacts')) {
             const id = {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -944,14 +944,11 @@ test('a completed `release-git` run updates the `main` branch in git-for-windows
     try {
         expect(await index(context, context.req)).toBeUndefined()
         expect(context.res).toEqual({
-            body: [
-                'Took care of pushing the `main` branch to close PR 765',
-                `The 'tag-git' workflow run was started at dispatched-workflow-tag-git.yml`,
-            ].join('\n'),
+            body: `Took care of pushing the \`main\` branch to close PR 765`,
             headers: undefined,
             status: undefined
         })
-        expect(mockGitHubApiRequest).toHaveBeenCalledTimes(7)
+        expect(mockGitHubApiRequest).toHaveBeenCalledTimes(4)
         expect(mockGitHubApiRequest.mock.calls[3].slice(1)).toEqual([
             'installation-access-token',
             'PATCH',


### PR DESCRIPTION
There are two situations when [the `upload-snapshot` workflow](https://github.com/git-for-windows/git-for-windows-automation/actions/workflows/upload-snapshot.yml) needs to be triggered:

1. For regular updates of Git for Windows:
   1. A regular `git-for-windows/git` PR is merged, which means that `main` is updated.
   2. This triggers a [`tag-git` workflow](https://github.com/git-for-windows/git-for-windows-automation/actions/workflows/tag-git.yml) run with the `snapshot` flag set to `true`.
   3. Once that `tag-git` run completes, GitForWindowsHelper triggers [`git-artifacts` workflow](https://github.com/git-for-windows/git-for-windows-automation/actions/workflows/git-artifacts.yml) runs for x86_64, aarch64 and i686 each.
   4. Once the last of these three `git-artifacts` runs completes with success, GitForWindowsHelper triggers the `upload-snapshot` workflow run.
2. For "Rebase to &lt;git-version&gt;" PRs:
   1. In those PRs, to "branch-deploy", a [`/git-artifacts` slash command](https://github.com/git-for-windows/gfw-helper-github-app/?tab=readme-ov-file#git-artifacts) triggers the `tag-git` workflow, this time with `snapshot` set to `false`.
   2. Just like above, once the `tag-git` run completes successfully, the `git-artifacts` workflow runs are triggered.
   3. After the last of these three `git-artifacts` runs completes with success, the PR author is expected to run [the manual tests](https://github.com/git-for-windows/build-extra/blob/main/installer/checklist.txt).
   4. Once the installer is validated, the PR author publishes the artifacts via [`/release`](https://github.com/git-for-windows/gfw-helper-github-app/?tab=readme-ov-file#release).
   5. This triggers the [`release-git` workflow](https://github.com/git-for-windows/git-for-windows-automation/actions/workflows/release-git.yml), which creates a new GitHub Release, among other things.
   6. Once the `release-git` workflow run concludes successfully, GitForWindowsHelper "merges" the PR by updating the `main` ref.
   7. This triggers a `push` webhook event, which GitForWindowsHelper needs to handle by triggering the `upload-snapshot` workflow run.

The difference between these two situations is, of course, that in the latter case, there are already the release artifacts, while in the former case, snapshot artifacts first need to be built.

Those code paths are slightly different; The snapshot artifacts case requires a far longer cascade which GitForWindowsHelper needs orchestrate by reacting to 5 webhook events (`push`, `tag-git` completion, 3x `git-artifacts` completion).

The "easier" code path is the one where the release artifacts are already there, and the `upload-snapshot` workflow run can be triggered immediately after the `push` event. However, that code path was broken, so that when [the v2.48.1 PR](https://github.com/git-for-windows/git/pull/5411) was "merged", no `upload-snapshot` workflow run was triggered. My analysis was incorrect and I missed that there probably _had_ been a `push` event. Based on my incorrect conclusion, I opened https://github.com/git-for-windows/gfw-helper-github-app/pull/124.

Since essentially the same code path was still responsible to handle the release artifacts scenario, unsurprisingly no `upload-snapshot` was triggered since #124 was merged. Meaning: We miss snapshots for v2.49.0-rc0 and v2.49.0-rc1 (and we missed v2.49.0-rc2 until I worked on this PR and ran the steps manually to upload [the v2.49.0-rc2 snapshot](https://github.com/git-for-windows/git-snapshots/releases/tag/2.49.0-rc2) by way of proving that my fixes are correct this time).

When I realized that the v2.49.0-rc2 snapshot had not been uploaded, I investigated, and found _two_ webhook events that resulted in failure: the `push` one (which I had assumed would not trigger on [updating a ref](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#update-a-reference)), and the `workflow_run.complete` one (handling the completed `release-git` workflow run, logic which I introduced in #124).

This here PR fixes those woes, and then reverts the change introduced in #124 to avoid double-triggering the `upload-snapshot` workflow run.

This closes https://github.com/git-for-windows/git/issues/5482