### PR TITLE
package.json: add support for auto-fixing lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "lint": "eslint -c eslint.config.js '**/*.js'",
+    "lint:fix": "eslint --fix -c eslint.config.js '**/*.js'",
     "test": "jest"
   }
 }


### PR DESCRIPTION
Simply run `npm run lint:fix`.