### PR TITLE
Hopefully fix those dreaded 😕 reactions by GitForWindowsHelper

### DIFF
--- a/.funcignore
+++ b/.funcignore
@@ -1,5 +1,9 @@
 /.*
+/*.config.js
 /*.md
 /*.gif
+/*.svg
 /host.json
 /local.settings.json
+/package*.json
+/test-*.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: Azure/functions-action@v1
         with:
-          app-name: GitForWindowsHelper
+          app-name: ${{ secrets.AZURE_FUNCTION_NAME || 'GitForWindowsHelper' }}
           publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
           respect-funcignore: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ on:
       - '.github/workflows/deploy.yml'
       - 'GitForWindowsHelper/**'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     if: github.event.repository.fork == false
@@ -16,9 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: 'Login via Azure CLI'
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_RBAC_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - uses: Azure/functions-action@v1
         with:
           app-name: ${{ secrets.AZURE_FUNCTION_NAME || 'GitForWindowsHelper' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_RBAC_CREDENTIALS }}
       - uses: Azure/functions-action@v1
         with:
           app-name: ${{ secrets.AZURE_FUNCTION_NAME || 'GitForWindowsHelper' }}
-          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
           respect-funcignore: true

--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -1,3 +1,5 @@
+const { activeOrg } = require('./org')
+
 const getToken = (() => {
     const tokens = {}
 
@@ -33,7 +35,7 @@ const triggerGitArtifactsRuns = async (context, checkRunOwner, checkRunRepo, tag
     const owner = match[1]
     const repo = match[2]
     const workflowRunId = Number(match[3])
-    if (owner !== 'git-for-windows' || repo !== 'git-for-windows-automation') {
+    if (owner !== activeOrg || repo !== 'git-for-windows-automation') {
         throw new Error(`Unexpected repository ${owner}/${repo} for tag-git run ${tagGitCheckRun.id}: ${tagGitCheckRun.url}`)
     }
 
@@ -120,7 +122,7 @@ const cascadingRuns = async (context, req) => {
 
     if (action === 'completed') {
         if (name === 'tag-git') {
-            if (checkRunOwner !== 'git-for-windows' || checkRunRepo !== 'git') {
+            if (checkRunOwner !== activeOrg || checkRunRepo !== 'git') {
                 throw new Error(`Refusing to handle cascading run in ${checkRunOwner}/${checkRunRepo}`)
             }
 

--- a/GitForWindowsHelper/cascading-runs.js
+++ b/GitForWindowsHelper/cascading-runs.js
@@ -1,4 +1,4 @@
-const { activeOrg } = require('./org')
+const { activeBot, activeOrg } = require('./org')
 
 const getToken = (() => {
     const tokens = {}
@@ -14,7 +14,7 @@ const getToken = (() => {
 })()
 
 const isAllowed = async (context, owner, repo, login) => {
-    if (login === 'gitforwindowshelper[bot]') return true
+    if (login === `${activeBot}[bot]`) return true
     const getCollaboratorPermissions = require('./get-collaborator-permissions')
     const token = await getToken(context, owner, repo)
     const permission = await getCollaboratorPermissions(context, token, owner, repo, login)
@@ -117,8 +117,8 @@ const cascadingRuns = async (context, req) => {
     const checkRunRepo = req.body.repository.name
     const checkRun = req.body.check_run
     const name = checkRun.name
-    const sender = req.body.sender.login === 'ghost' && checkRun?.app?.slug === 'gitforwindowshelper'
-        ? 'gitforwindowshelper[bot]' : req.body.sender.login
+    const sender = req.body.sender.login === 'ghost' && checkRun?.app?.slug === activeBot
+        ? `${activeBot}[bot]` : req.body.sender.login
 
     if (action === 'completed') {
         if (name === 'tag-git') {

--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -1,3 +1,5 @@
+const { activeOrg } = require('./org')
+
 const guessComponentUpdateDetails = (title, body) => {
     let [ , package_name, version ] =
         title.match(/^\[New (\S+) version\] (?:[^0-9]+\s+)?(\S+(?:\s+patch\s+\d+)?)(?! new items)/) ||
@@ -115,14 +117,14 @@ const guessReleaseNotes = async (context, issue) => {
         const match = issue.body.match(/See (https:\/\/\S+) for details/)
         if (match) return match[1]
 
-        const issueMatch = issue.body.match(/https:\/\/github\.com\/git-for-windows\/git\/issues\/(\d+)/)
+        const issueMatch = issue.body.match(new RegExp(`https://github.com/${activeOrg}/git/issues/(\\d+)`))
         if (issueMatch) {
             const githubApiRequest = require('./github-api-request')
             const issue = await githubApiRequest(
                 context,
                 null,
                 'GET',
-                `/repos/git-for-windows/git/issues/${issueMatch[1]}`
+                `/repos/${activeOrg}/git/issues/${issueMatch[1]}`
             )
             return matchURLInIssue(issue)
         }

--- a/GitForWindowsHelper/finalize-g4w-release.js
+++ b/GitForWindowsHelper/finalize-g4w-release.js
@@ -1,9 +1,11 @@
+const { activeOrg } = require('./org')
+
 module.exports = async (context, req) => {
     if (req.body.action !== 'completed') return "Nothing to do here: workflow run did not complete yet"
     if (req.body.workflow_run.conclusion !== 'success') return "Nothing to do here: workflow run did not succeed"
 
     const releaseWorkflowRunID = req.body.workflow_run.id
-    const owner = 'git-for-windows'
+    const owner = activeOrg
     const repo = 'git'
     const sender = req.body.sender.login
 
@@ -31,11 +33,11 @@ module.exports = async (context, req) => {
     if (!await isAllowed(sender)) throw new Error(`${sender} is not allowed to do that`)
 
     const { searchIssues } = require('./search')
-    const items = await searchIssues(context, 'org:git-for-windows is:pr is:open in:comments "The release-git workflow run was started"')
+    const items = await searchIssues(context, `org:${activeOrg} is:pr is:open in:comments "The release-git workflow run was started"`)
 
     const githubApiRequest = require('./github-api-request')
 
-    const needle = `The \`release-git\` workflow run [was started](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/${releaseWorkflowRunID})`
+    const needle = `The \`release-git\` workflow run [was started](https://github.com/${activeOrg}/git-for-windows-automation/actions/runs/${releaseWorkflowRunID})`
     const candidates = []
     for (const item of items) {
         if (!['OWNER', 'MEMBER'].includes(item.author_association)) continue

--- a/GitForWindowsHelper/finalize-g4w-release.js
+++ b/GitForWindowsHelper/finalize-g4w-release.js
@@ -1,4 +1,4 @@
-const { activeOrg } = require('./org')
+const { activeOrg, activeBot } = require('./org')
 
 module.exports = async (context, req) => {
     if (req.body.action !== 'completed') return "Nothing to do here: workflow run did not complete yet"
@@ -23,7 +23,7 @@ module.exports = async (context, req) => {
     })()
 
     const isAllowed = async (login) => {
-        if (login === 'gitforwindowshelper[bot]') return true
+        if (login === `${activeBot}[bot]`) return true
         const getCollaboratorPermissions = require('./get-collaborator-permissions')
         const token = await getToken()
         const permission = await getCollaboratorPermissions(context, token, owner, repo, login)

--- a/GitForWindowsHelper/https-request.js
+++ b/GitForWindowsHelper/https-request.js
@@ -25,7 +25,7 @@ const httpsRequest = async (context, hostname, method, requestPath, body, header
             options.method === 'GET' ? '' : `-X ${options.method}`,
             ...Object.entries(options.headers).map(([key, value]) => `-H ${quote(`${key}: ${value}`)}`),
             body ? `-d ${quote(body)}` : '',
-            `https://${options.hostname}${options.path}`,
+            `'https://${options.hostname}${encodeURI(options.path)}'`,
         ].filter(e => e).join(' ')
         ;(context.error || console.error)(commandLine)
     }

--- a/GitForWindowsHelper/index.js
+++ b/GitForWindowsHelper/index.js
@@ -1,5 +1,5 @@
 const validateGitHubWebHook = require('./validate-github-webhook')
-const { activeOrg } = require('./org')
+const { activeBot, activeOrg } = require('./org')
 
 module.exports = async function (context, req) {
     const withStatus = (status, headers, body) => {
@@ -54,7 +54,7 @@ module.exports = async function (context, req) {
     try {
         const { cascadingRuns, handlePush } = require('./cascading-runs.js')
         if (req.headers['x-github-event'] === 'check_run'
-            && req.body.check_run?.app?.slug === 'gitforwindowshelper'
+            && req.body.check_run?.app?.slug === activeBot
             && req.body.repository.full_name === `${activeOrg}/git`
             && req.body.action === 'completed') return ok(await cascadingRuns(context, req))
 

--- a/GitForWindowsHelper/index.js
+++ b/GitForWindowsHelper/index.js
@@ -1,4 +1,5 @@
 const validateGitHubWebHook = require('./validate-github-webhook')
+const { activeOrg } = require('./org')
 
 module.exports = async function (context, req) {
     const withStatus = (status, headers, body) => {
@@ -41,7 +42,7 @@ module.exports = async function (context, req) {
         if (req.headers['x-github-event'] === 'workflow_run'
             && req.body.workflow_run?.event === 'workflow_dispatch'
             && req.body.workflow_run?.head_branch === 'main'
-            && req.body.repository.full_name === 'git-for-windows/git-for-windows-automation'
+            && req.body.repository.full_name === `${activeOrg}/git-for-windows-automation`
             && req.body.action === 'completed'
             && req.body.workflow_run.path === '.github/workflows/release-git.yml'
             && req.body.workflow_run.conclusion === 'success') return ok(await finalizeGitForWindowsRelease(context, req))
@@ -54,7 +55,7 @@ module.exports = async function (context, req) {
         const { cascadingRuns, handlePush } = require('./cascading-runs.js')
         if (req.headers['x-github-event'] === 'check_run'
             && req.body.check_run?.app?.slug === 'gitforwindowshelper'
-            && req.body.repository.full_name === 'git-for-windows/git'
+            && req.body.repository.full_name === `${activeOrg}/git`
             && req.body.action === 'completed') return ok(await cascadingRuns(context, req))
 
         if (req.headers['x-github-event'] === 'push'

--- a/GitForWindowsHelper/org.js
+++ b/GitForWindowsHelper/org.js
@@ -1,0 +1,3 @@
+module.exports = {
+    activeOrg: process.env.ACTIVE_ORG || 'git-for-windows'
+}

--- a/GitForWindowsHelper/org.js
+++ b/GitForWindowsHelper/org.js
@@ -1,3 +1,4 @@
 module.exports = {
-    activeOrg: process.env.ACTIVE_ORG || 'git-for-windows'
+    activeOrg: process.env.ACTIVE_ORG || 'git-for-windows',
+    activeBot: process.env.ACTIVE_BOT || 'gitforwindowshelper',
 }

--- a/GitForWindowsHelper/trigger-workflow-dispatch.js
+++ b/GitForWindowsHelper/trigger-workflow-dispatch.js
@@ -39,15 +39,19 @@ const triggerWorkflowDispatch = async (context, token, owner, repo, workflow_id,
     if ('true' === process.env.DO_NOT_TRIGGER_ANYTHING) {
         throw new Error(`Would have triggered workflow ${workflow_id} on ${owner}/${repo} with ref ${ref} and inputs ${JSON.stringify(inputs)}`)
     }
-    const { headers: { date } } = await githubApiRequest(
+    const response = await githubApiRequest(
         context,
         token,
         'POST',
         `/repos/${owner}/${repo}/actions/workflows/${workflow_id}/dispatches`,
-        { ref, inputs }
+        { ref, inputs, return_run_details: true }
     )
 
-    // to avoid any potential clock skew, we set the "after" time to 5 seconds before the current time
+    // If the API returned run details (200), use them directly
+    if (response.workflow_run_id) return response
+
+    // Fall back to polling if we got a 204 (no run details)
+    const date = response.headers?.date || new Date().toISOString()
     const after = new Date(Date.parse(date) - 5000).toISOString()
     const runs = await waitForWorkflowRun(context, owner, repo, workflow_id, after, token)
     return runs[0]

--- a/GitForWindowsHelper/trigger-workflow-dispatch.js
+++ b/GitForWindowsHelper/trigger-workflow-dispatch.js
@@ -47,7 +47,9 @@ const triggerWorkflowDispatch = async (context, token, owner, repo, workflow_id,
         { ref, inputs }
     )
 
-    const runs = await waitForWorkflowRun(context, owner, repo, workflow_id, new Date(date).toISOString(), token)
+    // to avoid any potential clock skew, we set the "after" time to 5 seconds before the current time
+    const after = new Date(Date.parse(date) - 5000).toISOString()
+    const runs = await waitForWorkflowRun(context, owner, repo, workflow_id, after, token)
     return runs[0]
 }
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,17 @@ This process looks a bit complex, but the main reason for that is that three thi
 
 First of all, a new [Azure Function](https://portal.azure.com/#blade/HubsExtension/BrowseResourceBlade/resourceType/Microsoft.Web%2Fsites/kind/functionapp) was created. A Linux one was preferred, for cost and performance reasons. Deployment with GitHub was _not_ yet configured.
 
-#### Getting the "publish profile"
+#### Obtaining the Azure credentials
 
-After the deployment succeeded, in the "Overview" tab, there is a "Get publish profile" link on the right panel at the center top. Clicking it will automatically download a `.json` file whose contents will be needed later.
+The idea is to use [Role-Based Access Control (RBAC)](https://github.com/Azure/functions-action?tab=readme-ov-file#using-azure-service-principal-for-rbac-as-deployment-credential) to log into Azure in the deploy workflow. Essentially, after the deployment succeeded, in an Azure CLI (for example [the one that is very neatly embedded in the Azure Portal](https://learn.microsoft.com/en-us/azure/cloud-shell/get-started/classic)), run this (after replacing the placeholders `{subscription-id}`, `{resource-group}` and `{app-name}`):
+
+```shell
+az ad sp create-for-rbac --name "myApp" --role contributor \
+  --scopes /subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.Web/sites/{app-name} \
+  --sdk-auth
+```
+
+The result is called an "Azure Service Principal" in Azure Speak; Essentially it is a tightly-scoped credential that allows deploying this particular Azure Function and that's it. This Azure Service Principal will be the value of the `AZURE_RBAC_CREDENTIALS` Actions secret, more on that below.
 
 #### Some environment variables
 
@@ -125,7 +133,7 @@ Concretely, the environment variables `GITHUB_WEBHOOK_SECRET`, `GITHUB_APP_PRIVA
 
 On https://github.com/, the `+` link on the top was pressed, and an empty, private repository was registered. Nothing was pushed to it yet.
 
-After that, the contents of the publish profile that [was downloaded earlier](#getting-the-publish-profile) was registered as Actions secret, under the name `AZURE_FUNCTIONAPP_PUBLISH_PROFILE`.
+After that, the Azure Service Principal needs to be registered as Actions secret, under the name `AZURE_RBAC_CREDENTIALS`.
 
 This repository was initialized locally only after that, actually, by starting to write this `README.md` and then developing this working toy GitHub App, and the `origin` remote was set to the newly registered repository on GitHub.
 

--- a/README.md
+++ b/README.md
@@ -113,15 +113,25 @@ First of all, a new [Azure Function](https://portal.azure.com/#blade/HubsExtensi
 
 #### Obtaining the Azure credentials
 
-The idea is to use [Role-Based Access Control (RBAC)](https://github.com/Azure/functions-action?tab=readme-ov-file#using-azure-service-principal-for-rbac-as-deployment-credential) to log into Azure in the deploy workflow. Essentially, after the deployment succeeded, in an Azure CLI (for example [the one that is very neatly embedded in the Azure Portal](https://learn.microsoft.com/en-us/azure/cloud-shell/get-started/classic)), run this (after replacing the placeholders `{subscription-id}`, `{resource-group}` and `{app-name}`):
+The idea is to use [OpenID Connect](https://docs.github.com/en/actions/concepts/security/openid-connect) to log into Azure in the deploy workflow, _identifying_ as said workflow, via a "Managed Identity". This can be registered after the Azure Function has been successfully created: In an Azure CLI (for example [the one that is very neatly embedded in the Azure Portal](https://learn.microsoft.com/en-us/azure/cloud-shell/get-started/classic)), run this (after replacing the placeholders `{subscription-id}`, `{resource-group}` and `{app-name}`):
 
 ```shell
-az ad sp create-for-rbac --name "myApp" --role contributor \
-  --scopes /subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.Web/sites/{app-name} \
-  --sdk-auth
+az identity create --name <managed-identity-name> -g <resource-group>
+az identity federated-credential create \
+  --identity-name <managed-identity-name> \
+  --resource-group <resource-group> \
+  --name github-workflow \
+  --issuer https://token.actions.githubusercontent.com \
+  --subject repo:<org>/gfw-helper-github-app:environment:deploy-to-azure \
+  --audiences api://AzureADTokenExchange
+# The scope can be copied from the Azure Portal URL after navigating to the Azure Function
+az role assignment create \
+  --assignee <client-id-of-managed-identity> \
+  --scope '/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Web/sites/<azure-function-name>' \
+  --role 'Contributor'
 ```
 
-The result is called an "Azure Service Principal" in Azure Speak; Essentially it is a tightly-scoped credential that allows deploying this particular Azure Function and that's it. This Azure Service Principal will be the value of the `AZURE_RBAC_CREDENTIALS` Actions secret, more on that below.
+The result is a "managed identity", essentially a tightly-scoped credential that allows deploying this particular Azure Function from that particular repository in a GitHub workflow run and that's it. This managed identity is identified via the `AZURE_CLIENT_ID`, `AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID` Actions secrets, more on that below.
 
 #### Some environment variables
 
@@ -131,7 +141,7 @@ Concretely, the environment variables `GITHUB_WEBHOOK_SECRET`, `GITHUB_APP_PRIVA
 
 ### The repository
 
-On https://github.com/, the `+` link on the top was pressed, and an empty, private repository was registered. Nothing was pushed to it yet.
+Create a fork of https://github.com/git-for-windows/gfw-helper-github-app. Configure the Azure Managed Identity via Actions secrets, under the keys `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`. Also, the `AZURE_FUNCTION_NAME` secret needs to be defined (its value is the name of the Azure Function).
 
 After that, the Azure Service Principal needs to be registered as Actions secret, under the name `AZURE_RBAC_CREDENTIALS`.
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -798,6 +798,9 @@ test('a completed `tag-git` run triggers `git-artifacts` runs', async () => {
                 slug: 'gitforwindowshelper',
             },
         },
+        sender: {
+            login: 'ghost'
+        },
         installation: {
             id: 123
         },
@@ -998,6 +1001,9 @@ test('the third completed `git-artifacts-<arch>` check-run triggers an `upload-s
             app: {
                 slug: 'gitforwindowshelper',
             },
+        },
+        sender: {
+            login: 'ghost'
         },
         installation: {
             id: 123

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -91,6 +91,12 @@ let mockGitHubApiRequest = jest.fn((_context, _token, method, requestPath, paylo
             path: `.github/workflows/${match[1]}`,
             payload
         })
+        // Exercise the 204 fallback path for upload-snapshot.yml
+        if (payload?.return_run_details && match[1] !== 'upload-snapshot.yml') return {
+            workflow_run_id: 12345,
+            run_url: `https://api.github.com/repos/test/test/actions/runs/12345`,
+            html_url: `dispatched-workflow-${match[1]}`
+        }
         return {
             headers: {
                 date: (new Date()).toISOString()
@@ -338,14 +344,16 @@ The MINGW workflow run [was started](dispatched-workflow-open-pr.yml)`,
     expect(dispatchedWorkflows).toHaveLength(2)
     expect(dispatchedWorkflows.map(e => e.payload.inputs.package)).toEqual(['mingw-w64-gnutls', 'gnutls'])
     expect(mockGitHubApiRequest).toHaveBeenCalled()
-    const msysComment = mockGitHubApiRequest.mock.calls[mockGitHubApiRequest.mock.calls.length - 6]
+    const patchCalls = mockGitHubApiRequest.mock.calls.filter(c => c[2] === 'PATCH')
+    expect(patchCalls).toHaveLength(2)
+    const msysComment = patchCalls[0]
     expect(msysComment[3]).toEqual('/repos/git-for-windows/git/issues/comments/0')
     expect(msysComment[4]).toEqual({
         body: `existing comment body
 
 The MSYS workflow run [was started](dispatched-workflow-open-pr.yml)`
     })
-    const mingwComment = mockGitHubApiRequest.mock.calls[mockGitHubApiRequest.mock.calls.length - 1]
+    const mingwComment = patchCalls[1]
     expect(mingwComment[3]).toEqual('/repos/git-for-windows/git/issues/comments/0')
     expect(mingwComment[4]).toEqual({
         body: `existing comment body
@@ -834,7 +842,8 @@ The \`git-artifacts-aarch64\` workflow run [was started](dispatched-workflow-git
                 inputs: {
                     architecture: 'i686',
                     tag_git_workflow_run_id: "4322343196"
-                }
+                },
+                return_run_details: true
             }
         ])
     } catch (e) {
@@ -1041,7 +1050,8 @@ test('the third completed `git-artifacts-<arch>` check-run triggers an `upload-s
                     git_artifacts_aarch64_workflow_run_id: "13010016895",
                     git_artifacts_i686_workflow_run_id: "13010015938",
                     git_artifacts_x86_64_workflow_run_id: "13010015190"
-                }
+                },
+                return_run_details: true
             }
         ])
     } catch (e) {

--- a/get-webhook-event-payload.js
+++ b/get-webhook-event-payload.js
@@ -12,7 +12,7 @@
     while (args.length) {
         let option = args.shift()
 
-        const issueCommentMatch = option.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/\d+#issuecomment-(\d+)$/)
+        const issueCommentMatch = option.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/(?:pull|issues)\/\d+#issuecomment-(\d+)$/)
         if (issueCommentMatch) {
             eventType = 'issue_comment'
             const githubRequest = require('./GitForWindowsHelper/github-api-request')

--- a/test-pr-comment-delivery.js
+++ b/test-pr-comment-delivery.js
@@ -70,6 +70,7 @@
     // avoid accidentally triggering anything
     delete process.env.GITHUB_APP_PRIVATE_KEY
     process.env.DO_NOT_TRIGGER_ANYTHING = 'true'
+    process.env.LOG_HTTPS_REQUESTS = 'true'
 
     const index = require('./GitForWindowsHelper/index')
     console.log(await index(context, req) || context.res)


### PR DESCRIPTION
Ever since GitHub changed their REST API so that the date range in their `search` endpoint didn't work as expected by GitForWindowsHelper's logic anymore, I've been struggling to find a work around or fix for this. I thought that I had at at long last figured out the correct syntax in 77cd499eff02d682f543ce42079dddc1302dedbd (after none of https://github.com/git-for-windows/gfw-helper-github-app/commit/1ff8966166291b1c67dd6b68c7b55c346a7dffd0, https://github.com/git-for-windows/gfw-helper-github-app/commit/a4e3ff861a701153fff69db865644534f8f0b35c, https://github.com/git-for-windows/gfw-helper-github-app/commit/2627695f0e38d4ea166210b9d913c1567d870655 and https://github.com/git-for-windows/gfw-helper-github-app/commit/2e91f073c335056672d40d37a51ab253f120acb4 did the job) but today we experienced another of those dreaded :confused: reactions in https://github.com/git-for-windows/git/issues/6097#issuecomment-3914791350:

<img width="288" height="100" alt="image" src="https://github.com/user-attachments/assets/da852ab2-1441-4894-b542-cbaef240ff2a" />

The response for that webhook is simply empty, because it timed out before responding, unfortunately:

<img width="1046" height="217" alt="image" src="https://github.com/user-attachments/assets/853056fb-5b47-4dc5-bfb5-ba1e028b3da6" />

I actually had started looking into this a little over a week ago (using the embargoed org to perform my experiments because I did not want to mess around with the `main` branch of `git-for-windows-automation` in production). And it _looks_ as if the `date:` header returned in that unhelpful 204 that is the (otherwise empty) response when [creating a workflow dispatch event](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event) can be either identical to, or even come _after_, the date reported as the `created_at` attribute of the corresponding workflow run.

To be sure, the root cause behind all of these troubles is that for all those years, there was a really annoying gap in GitHub's REST API. It should be so easy to obtain the corresponding workflow run when triggering one via a `workflow_dispatch`: Literally everybody who triggers a workflow run programmatically needs to obtain a reference to the workflow run that was triggered by it. That's necessary. This is required. However, there is no reliable way. And what we did was just to work around that. By polling for workflow runs that were created _after_ we asked for one to be triggered. And even those workarounds were broken, so the entire saga is _quite_ frustrating.

The good news: After years of frustration, it seems that some new wind was blown into GitHub Actions, and they fixed that! See https://github.blog/changelog/2026-02-19-workflow-dispatch-api-now-returns-run-ids/ for full details.

Unfortunately, this is of course not enough. Apparently yet another external change prevented me from using the Role-Based Access Control (RBAC) method to deploy the Azure Function to the embargoed org, which was _already_ a work-around from back from April 2024, when I worked on creating artifacts for an embargoed Git for Windows release. Of course, I did expect this to deploy without problems, after I verified in my experiments that the clock skew patch works around the new issues in a local run-through. So I basically merged those changes from the embargoed builds to be able to deploy. But the deployment failed, RBAC no longer works, and I documented that in the follow-up commit: Luckily, for completely unrelated reasons, elsewhere (in GitGitGadget), I had already developed patches to deploy an Azure Function via OpenID Connect. So I ported those changes to the Git for Windows helper app.

Unfortunately this still was not enough. I had to also allow for overriding not only the `activeOrg` but also the `activeBot`, because in the non-embargoed builds (i.e. in `git-for-windows/git-for-windows-automation`'s `main` branch), we now verify that the sender is the expected bot.

The end result is unfortunately a complex PR that tries to do something simple, but for various reasons needs to be a lot more complex just so that we can actually deploy the result...