### PR TITLE
slash-commands: add /snapshot command

### DIFF
--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -267,6 +267,88 @@ module.exports = async (context, req) => {
             return `I edited the comment: ${answer.html_url}`
         }
 
+        if (command === '/snapshot') {
+            if (owner !== activeOrg
+             || repo !== 'git'
+             || !req.body.issue.pull_request
+            ) {
+                return `Ignoring ${command} in unexpected repo: ${commentURL}`
+            }
+
+            await checkPermissions()
+            await thumbsUp()
+
+            const githubApiRequest = require('./github-api-request')
+            const pr = await githubApiRequest(
+                context,
+                await getToken(),
+                'GET',
+                `/repos/${owner}/${repo}/pulls/${issueNumber}`
+            )
+            const rev = pr.merge_commit_sha
+            if (!rev || pr.mergeable === false) {
+                throw new Error(`PR #${issueNumber} is not mergeable`)
+            }
+
+            const { queueCheckRun, updateCheckRun } = require('./check-runs')
+            const tagGitCheckRunTitle = `Snapshot @${rev}`
+            const tagGitCheckRunId = await queueCheckRun(
+                context,
+                await getToken(),
+                owner,
+                repo,
+                rev,
+                'tag-git',
+                tagGitCheckRunTitle,
+                tagGitCheckRunTitle
+            )
+
+            try {
+                const triggerWorkflowDispatch = require('./trigger-workflow-dispatch')
+                const answer = await triggerWorkflowDispatch(
+                    context,
+                    await getToken(),
+                    activeOrg,
+                    'git-for-windows-automation',
+                    'tag-git.yml',
+                    'main', {
+                        rev,
+                        owner,
+                        repo,
+                        snapshot: 'true'
+                    }
+                )
+
+                const { appendToIssueComment } = require('./issues')
+                const answer2 = await appendToIssueComment(
+                    context,
+                    await getToken(),
+                    owner,
+                    repo,
+                    commentId,
+                    `The \`tag-git\` workflow run [was started](${answer.html_url}) for merge commit ${rev}`
+                )
+                return `I edited the comment: ${answer2.html_url}`
+            } catch (e) {
+                await updateCheckRun(
+                    context,
+                    await getToken(),
+                    owner,
+                    repo,
+                    tagGitCheckRunId, {
+                        status: 'completed',
+                        conclusion: 'failure',
+                        output: {
+                            title: tagGitCheckRunTitle,
+                            summary: tagGitCheckRunTitle,
+                            text: e.message || JSON.stringify(e, null, 2)
+                        }
+                    }
+                )
+                throw e
+            }
+        }
+
         if (command === '/git-artifacts') {
             if (owner !== activeOrg
              || repo !== 'git'

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ For convenience, the command can be abbreviated as `/add relnote <type> <message
 
 **What does it do?** This triggers the `sync` GitHub workflow runs in Git for Windows' `git-sdk-*` repositories, i.e. updates them with the newest package versions as per the Pacman repositories.
 
+### `/snapshot`
+
+**Where can it be called?** In `git-for-windows/git`'s [Pull Requests](https://github.com/git-for-windows/git/pulls)
+
+**What does it do?** This command builds a snapshot from the PR's temporary merge commit. It triggers [`tag-git`](https://github.com/git-for-windows/git-for-windows-automation/actions/workflows/tag-git.yml) with the merge commit SHA and `snapshot: true`. The cascading `git-artifacts` runs will build installers for all architectures, but because the merge commit is not on `main`, no snapshot will be uploaded to `git-snapshots`.
+
 ### `/git-artifacts`
 
 **Where can it be called?** In `git-for-windows/git`'s [Pull Requests](https://github.com/git-for-windows/git/pulls)


### PR DESCRIPTION
When working on changes to Git for Windows, it is often useful to build a complete set of artifacts (installer, Portable Git, MinGit) to validate a fix before merging (e.g. [in this PR](https://github.com/git-for-windows/git/pull/6215#issuecomment-4335241797)). Currently, building such artifacts requires either merging to `main` first (which triggers automatic snapshot builds) or manually dispatching the `tag-git` workflow with the right parameters.

A `/snapshot` slash command on PRs makes this workflow much more accessible: trusted contributors and maintainers can simply comment `/snapshot` on a PR to get a full set of build artifacts for the PR's current state, without merging.

The command uses the PR's temporary merge commit (so the artifacts reflect what will land on `main`, not just the topic branch in isolation) and passes `snapshot: true` to the `tag-git` workflow. The existing safeguard in `cascading-runs.js` that checks whether the commit is on `main` prevents any upload to the `git-snapshots` repository, so this is safe to use on any PR.

Depends on https://github.com/git-for-windows/git-for-windows-automation/pull/168 for snapshot-aware PR comments (linking artifacts instead of asking to validate the installer).