### PR TITLE
component-updates: check pacman-repo, not the Azure Blob storage

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -143,7 +143,7 @@ const guessReleaseNotes = async (context, issue) => {
     }
 }
 
-const pacmanRepositoryBaseURL = 'https://wingit.blob.core.windows.net/'
+const pacmanRepositoryBaseURL = 'https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/'
 
 const pacmanRepositoryURLs = (package_name, version, architectures) =>
     architectures.map(arch => {
@@ -151,7 +151,7 @@ const pacmanRepositoryURLs = (package_name, version, architectures) =>
             ? `${package_name}-${version}-1-${arch}.pkg.tar.xz`
             : `${package_name.replace(/^mingw-w64/,
                 `$&-${arch === 'aarch64' ? `clang-${arch}` : arch}`)}-${version}-1-any.pkg.tar.xz`
-        return `${pacmanRepositoryBaseURL}${arch.replace(/_/g, '-')}/${fileName}`
+        return `${pacmanRepositoryBaseURL}${arch}/${fileName}`
     })
 
 const getMissingDeployments = async (package_name, version) => {

--- a/__tests__/component-updates.test.js
+++ b/__tests__/component-updates.test.js
@@ -83,13 +83,13 @@ href="20230616162552.879387-1-corinna-cygwin@cygwin.com/">cygwin 3.4.7-1</a></b>
 
 </pre>[... even more stuff...]</body></html>`
 }
-const missingURL = 'https://wingit.blob.core.windows.net/x86-64/curl-8.1.2-1-x86_64.pkg.tar.xz'
-const missingAarch64URL = 'https://wingit.blob.core.windows.net/aarch64/mingw-w64-clang-aarch64-curl-8.1.2-1-any.pkg.tar.xz'
-const missingMinTTYURL = 'https://wingit.blob.core.windows.net/i686/mintty-1~3.6.5-1-i686.pkg.tar.xz'
-const bogus32BitMSYS2RuntimeURL = 'https://wingit.blob.core.windows.net/i686/msys2-runtime-3.4.9-1-i686.pkg.tar.xz'
-const bogus64BitMSYS2RuntimeURL = 'https://wingit.blob.core.windows.net/x86-64/msys2-runtime-3.3-3.3.7-1-x86_64.pkg.tar.xz'
-const missingOpenSSHURL = 'https://wingit.blob.core.windows.net/i686/openssh-9.5p1-1-i686.pkg.tar.xz'
-const missingBashURL = 'https://wingit.blob.core.windows.net/x86-64/bash-5.2.020-1-x86_64.pkg.tar.xz'
+const missingURL = 'https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/x86_64/curl-8.1.2-1-x86_64.pkg.tar.xz'
+const missingAarch64URL = 'https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/aarch64/mingw-w64-clang-aarch64-curl-8.1.2-1-any.pkg.tar.xz'
+const missingMinTTYURL = 'https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/i686/mintty-1~3.6.5-1-i686.pkg.tar.xz'
+const bogus32BitMSYS2RuntimeURL = 'https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/i686/msys2-runtime-3.4.9-1-i686.pkg.tar.xz'
+const bogus64BitMSYS2RuntimeURL = 'https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/x86_64/msys2-runtime-3.3-3.3.7-1-x86_64.pkg.tar.xz'
+const missingOpenSSHURL = 'https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/i686/openssh-9.5p1-1-i686.pkg.tar.xz'
+const missingBashURL = 'https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/x86_64/bash-5.2.020-1-x86_64.pkg.tar.xz'
 const mockDoesURLReturn404 = jest.fn(url => [
     missingURL,
     missingAarch64URL,

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -731,7 +731,7 @@ The workflow run [was started](dispatched-workflow-build-and-deploy.yml).`)
     expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['i686'])
 })
 
-const missingURL = 'https://wingit.blob.core.windows.net/x86-64/mingw-w64-x86_64-git-lfs-3.4.0-1-any.pkg.tar.xz'
+const missingURL = 'https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/x86_64/mingw-w64-x86_64-git-lfs-3.4.0-1-any.pkg.tar.xz'
 const mockDoesURLReturn404 = jest.fn(url => url === missingURL)
 jest.mock('../GitForWindowsHelper/https-request', () => {
     return { doesURLReturn404: mockDoesURLReturn404 }
@@ -779,7 +779,7 @@ testIssueComment({ comment: '/add release note', note: 'missing deployment' }, {
     expect(context.res).toEqual({
         body: `The following deployment(s) are missing:
 
-* https://wingit.blob.core.windows.net/x86-64/mingw-w64-x86_64-git-lfs-3.4.0-1-any.pkg.tar.xz`,
+* https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/x86_64/mingw-w64-x86_64-git-lfs-3.4.0-1-any.pkg.tar.xz`,
         headers: undefined,
         status: 500
     })


### PR DESCRIPTION
Until recently, Git for Windows uploaded Pacman packages to `wingit.blob.core.windows.net`, and the `/add relnote` flow verified the deployment by HEAD-probing each expected `.pkg.tar.xz` URL there. Now that the Azure Blob deployment is gone (see [build-extra@5b44c34](https://github.com/git-for-windows/build-extra/commit/5b44c34581782c792de7d5236b7bac6762efe9e4) and the surrounding work), every probe returns 404 and `/add relnote` always claims the deployment is missing. The first concrete fallout was [git-for-windows/git#6272 (comment)](https://github.com/git-for-windows/git/issues/6272#issuecomment-4671432007) where OpenSSL 3.5.7-1 was reported as undeployed despite the packages having landed at the tip of each arch branch in `git-for-windows/pacman-repo`.

This PR points the existing HEAD probe at the new home: `https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/<arch>/<filename>`. That URL serves the file at the branch tip, so blobs pruned from a tip will correctly report as missing (matching `pacman -Syu` semantics). The previous `arch.replace(/_/g, '-')` mapping `x86_64` to `x86-64` was a legacy Azure-container naming quirk and is dropped, since pacman-repo's branch is just `x86_64`.

Verified end-to-end against the live `git-for-windows/pacman-repo` tree:

```
openssl-3.5.7-1-x86_64.pkg.tar.xz => false (present)
openssl-9.9.9-1-x86_64.pkg.tar.xz => true  (missing)
mingw-w64-clang-aarch64-openssl-3.5.7-1-any.pkg.tar.xz => false (present)
```

All 25 existing tests pass; only the URL constants in the tests needed updating to match the new host.
