### PR TITLE
Let `/deploy` trigger individual workflow runs per architecture

### DIFF
--- a/GitForWindowsHelper/component-updates.js
+++ b/GitForWindowsHelper/component-updates.js
@@ -53,14 +53,15 @@ const packageNeedsBothMSYSAndMINGW = package_name => {
     return ['openssl', 'curl', 'gnutls', 'pcre2'].includes(package_name)
 }
 
-const needsSeparateARM64Build = package_name => {
-    if (package_name === 'git-extra') return true
-    return package_name.startsWith('mingw-w64-') && ![
-        'mingw-w64-git-credential-manager',
-        'mingw-w64-git-lfs',
-        'mingw-w64-wintoast'
-    ].includes(package_name)
-}
+// `mingw-w64-git-credential-manager`, `mingw-w64-git-lfs` and
+// `mingw-w64-wintoast` are not built per architecture by us; they are
+// cross-compiled via Visual Studio or downloaded as pre-built artifacts
+// for every architecture (including `clangarm64`) in a single run.
+const buildsAllArchitecturesInOneRun = package_name => [
+    'mingw-w64-git-credential-manager',
+    'mingw-w64-git-lfs',
+    'mingw-w64-wintoast'
+].includes(package_name)
 
 const guessCygwinReleaseNotesURL = async (version) => {
     const { fetchHTML } = require('./https-request')
@@ -200,6 +201,6 @@ module.exports = {
     prettyPackageName,
     isMSYSPackage,
     packageNeedsBothMSYSAndMINGW,
-    needsSeparateARM64Build,
+    buildsAllArchitecturesInOneRun,
     getMissingDeployments
 }

--- a/GitForWindowsHelper/slash-commands.js
+++ b/GitForWindowsHelper/slash-commands.js
@@ -152,7 +152,7 @@ module.exports = async (context, req) => {
 
             await checkPermissions()
 
-            const { guessComponentUpdateDetails, isMSYSPackage, needsSeparateARM64Build } = require('./component-updates')
+            const { guessComponentUpdateDetails, isMSYSPackage, buildsAllArchitecturesInOneRun } = require('./component-updates')
             const { package_name } = deployMatch[2]
                 ? { package_name: deployMatch[2] }
                 : guessComponentUpdateDetails(req.body.issue.title, req.body.issue.body)
@@ -207,17 +207,24 @@ module.exports = async (context, req) => {
                         { architecture: 'i686' }
                     )
                 }
+            } else if (buildsAllArchitecturesInOneRun(package_name)) {
+                // A single run builds every architecture (including
+                // `clangarm64`) for these packages; see the predicate's
+                // definition for details.
+                toTrigger.push(
+                    { displayArchitecture: 'i686/x86_64/ucrt64/arm64' }
+                )
             } else {
                 if (package_name !== 'mingw-w64-llvm') {
                     toTrigger.push(
-                        { displayArchitecture: 'i686/x86_64' }
+                        { architecture: 'i686' },
+                        { architecture: 'x86_64' },
+                        { architecture: 'ucrt64' }
                     )
                 }
-                if (needsSeparateARM64Build(package_name)) {
-                    toTrigger.push(
-                        { architecture: 'aarch64', displayArchitecture: 'arm64' }
-                    )
-                }
+                toTrigger.push(
+                    { architecture: 'aarch64', displayArchitecture: 'arm64' }
+                )
             }
 
             for (const e of toTrigger) {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -148,6 +148,9 @@ let mockGitHubApiRequest = jest.fn((_context, _token, method, requestPath, paylo
     if (method === 'GET' && requestPath.endsWith('/pulls/177')) return {
         head: { sha: '03bdffe5997'}
     }
+    if (method === 'GET' && requestPath.endsWith('/pulls/210')) return {
+        head: { sha: '9e7e7a1' }
+    }
     if (method === 'PATCH' && requestPath.endsWith('/git/refs/heads/main')) {
         if (payload.sha !== 'c0ffee1ab7e') throw new Error(`Unexpected sha: ${payload.sha}`)
         if (payload.force !== false) throw new Error(`Unexpected force value: ${payload.force}`)
@@ -591,10 +594,33 @@ testIssueComment('/deploy mingw-w64-curl', {
     expect(await index(context, context.req)).toBeUndefined()
     expect(context.res.body).toEqual(`I edited the comment: appended-comment-body-existing comment body
 
-The [i686/x86_64](dispatched-workflow-build-and-deploy.yml) and the [arm64](dispatched-workflow-build-and-deploy.yml) workflow runs were started.`)
-    expect(mockQueueCheckRun).toHaveBeenCalledTimes(2)
-    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(2)
-    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['aarch64', undefined])
+The [i686](dispatched-workflow-build-and-deploy.yml), the [x86_64](dispatched-workflow-build-and-deploy.yml), the [ucrt64](dispatched-workflow-build-and-deploy.yml) and the [arm64](dispatched-workflow-build-and-deploy.yml) workflow runs were started.`)
+    expect(mockQueueCheckRun).toHaveBeenCalledTimes(4)
+    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(4)
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['aarch64', 'ucrt64', 'x86_64', 'i686'])
+})
+
+testIssueComment('/deploy git-extra', {
+    issue: {
+        number: 210,
+        title: 'git-extra: bump version',
+        body: '',
+        pull_request: {
+            html_url: 'https://github.com/git-for-windows/build-extra/pull/210'
+        }
+    },
+    repository: {
+        name: 'build-extra'
+    }
+}, async (context) => {
+    expect(await index(context, context.req)).toBeUndefined()
+    expect(context.res.body).toEqual(`I edited the comment: appended-comment-body-existing comment body
+
+The [i686](dispatched-workflow-build-and-deploy.yml), the [x86_64](dispatched-workflow-build-and-deploy.yml), the [ucrt64](dispatched-workflow-build-and-deploy.yml) and the [arm64](dispatched-workflow-build-and-deploy.yml) workflow runs were started.`)
+    expect(mockQueueCheckRun).toHaveBeenCalledTimes(4)
+    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(4)
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.architecture)).toEqual(['aarch64', 'ucrt64', 'x86_64', 'i686'])
+    expect(dispatchedWorkflows.map(e => e.payload.inputs.package)).toEqual(['git-extra', 'git-extra', 'git-extra', 'git-extra'])
 })
 
 testIssueComment('/deploy msys2-runtime', {


### PR DESCRIPTION
Currently, `/deploy` spawns _two_ workflow runs for regular MINGW packages: one that builds the `clangarm64` variant of the package, and one that combines the `mingw32` and `mingw64` builds.

(Exceptions: `git-credential-manager`, `git-lfs` and `wintoast`, where the executables are not actually built using the MINGW toolchains provided by the MSYS2 project.)

With the currently ongoing [migration](https://github.com/git-for-windows/git-sdk-64/pull/117) from MINGW64 to UCRT64, it is as good a time as any to split that combined build, and simply trigger separate workflow runs for all the separate MINGW flavors (`MINGW_ARCH` in MSYS2 parlance).

This _also_ prepares for dramatically restricting the set of packages to be updated in the 32-bit builds of Git for Windows: Even though Git for Windows promises to provide MinGit 32-bit builds [until 2029](https://gitforwindows.org/32-bit#until-2029-mingit-only-32-bit-support), the uphill battle to maintain 32-bit support requires making concessions by focusing on an even smaller set of components that _must_ be updated for that architecture. I am thinking about cURL, OpenSSL and OpenSSH, and stopping to update, say, PCRE2 and xpdf-tools for 32-bit. Bash, for example, is [no longer updated](https://github.com/git-for-windows/gfw-helper-github-app/pull/192) for 32-bit at all.